### PR TITLE
Debug pulse kernel

### DIFF
--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -44,7 +44,7 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "pulse_kernel_gaussian_smearing_width",
-        default=700_000,  # The original Matlab code says 7 samples (with fs = 1E5Hz).
+        default=14_000,  # The original Matlab code says 7 samples (with fs = 1E5Hz).
         track=True,
         type=int,
         help=(
@@ -61,13 +61,13 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "pulse_kernel_truncation_factor",
-        default=5,
+        default=10,
         track=True,
         type=float,
         help=(
             "Factor for truncating the pulse kernel to improve performance. "
             "The kernel is truncated after truncation_factor * tau samples, "
-            "where the exponential decay becomes negligible (< 0.7% of peak value)."
+            "where the exponential decay becomes negligible."
         ),
     ),
 )
@@ -248,7 +248,7 @@ class PulseProcessing(strax.Plugin):
 
     @staticmethod
     def pulse_kernel_emg(ns, fs, t0, tau, sigma, truncation_factor=5):
-        """Generate a pulse train with exponential decay and Gaussian smoothing.
+        """Generate a pulse train with truncated exponential decay and Gaussian smoothing.
 
         Translated from Chris Albert's Matlab codes:
         https://caltechobscosgroup.slack.com/archives/C07SZDKRNF9/p1752010145654029.
@@ -286,15 +286,15 @@ class PulseProcessing(strax.Plugin):
         # Apply Gaussian smoothing.
         pulse_kernal = gaussian_filter1d(exponential, sigma=sigma_sample)
 
-        # No need for truncation since we already computed only the significant portion
-        # But we still need to normalize
+        # No need for truncation since we already computed only the significant portion.
+        # But we still need to normalize.
         kernel_sum = np.sum(pulse_kernal)
-        if kernel_sum > 0:  # Avoid division by zero
+        if kernel_sum > 0:  # Avoid division by zero.
             pulse_kernal /= kernel_sum
 
         # Normalize again to make sure the integral is 1.
         kernel_sum = np.sum(pulse_kernal)
-        if kernel_sum > 0:  # Avoid division by zero
+        if kernel_sum > 0:  # Avoid division by zero.
             pulse_kernal /= kernel_sum
 
         return pulse_kernal

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -163,6 +163,8 @@ class PulseProcessing(strax.Plugin):
 
         self.finescan = self.load_finescan_files(self.config["iq_finescan_dir"])
         self.finescan_available_channels = sorted(self.finescan.keys())
+
+        # Pre-compute pulse kernel.
         self.kernel = np.flip(
             self.pulse_kernel_emg(
                 self.record_length,
@@ -174,7 +176,7 @@ class PulseProcessing(strax.Plugin):
             )
         )
 
-        # Pre-compute moving average kernel
+        # Pre-compute moving average kernel.
         moving_average_kernel_width = int(self.config["moving_average_width"] / self.dt)
         self.moving_average_kernel = (
             np.ones(moving_average_kernel_width) / moving_average_kernel_width

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -163,13 +163,15 @@ class PulseProcessing(strax.Plugin):
 
         self.finescan = self.load_finescan_files(self.config["iq_finescan_dir"])
         self.finescan_available_channels = sorted(self.finescan.keys())
-        self.kernel = self.pulse_kernel_emg(
-            self.record_length,
-            self.config["fs"],
-            self.config["pulse_kernel_start_time"],
-            self.config["pulse_kernel_decay_time"],
-            self.config["pulse_kernel_gaussian_smearing_width"],
-            self.config["pulse_kernel_truncation_factor"],
+        self.kernel = np.flip(
+            self.pulse_kernel_emg(
+                self.record_length,
+                self.config["fs"],
+                self.config["pulse_kernel_start_time"],
+                self.config["pulse_kernel_decay_time"],
+                self.config["pulse_kernel_gaussian_smearing_width"],
+                self.config["pulse_kernel_truncation_factor"],
+            )
         )
 
         # Pre-compute moving average kernel

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -269,21 +269,21 @@ class PulseProcessing(strax.Plugin):
         """
         dt = int(1 / fs * SECOND_TO_NANOSECOND)
 
-        # Calculate significant length upfront to avoid unnecessary computation
-        significant_length = min(ns, int(truncation_factor * tau / dt))
+        # Calculate significant length upfront to avoid unnecessary computation.
+        significant_length = min(ns, int((truncation_factor * tau + t0) / dt))
 
-        # Only create time array for needed samples
+        # Only create time array for needed samples.
         t = np.arange(significant_length) * dt
 
-        # Create exponential decay pulse only for significant portion
+        # Create exponential decay pulse only for significant portion.
         mask = t >= t0
         exponential = np.zeros(significant_length)
         exponential[mask] = np.exp(-(t[mask] - t0) / tau)
 
-        # Convert sigma to samples
+        # Convert sigma to samples.
         sigma_sample = int(sigma / dt)
 
-        # Apply Gaussian smoothing
+        # Apply Gaussian smoothing.
         pulse_kernal = gaussian_filter1d(exponential, sigma=sigma_sample)
 
         # No need for truncation since we already computed only the significant portion

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -168,10 +168,10 @@ class TestLoadFinescanFiles:
             shutil.rmtree(empty_dir)
 
 
-class TestPulseKernelEMG:
-    """Test the pulse_kernel_emg static method of PulseProcessing class."""
+class TestPulseKernel:
+    """Test the pulse_kernel static method of PulseProcessing class."""
 
-    def test_pulse_kernel_emg_basic(self):
+    def test_pulse_kernel_basic(self):
         """Test basic pulse kernel generation with typical parameters."""
         ns = 10000
         fs = 100000  # 100 kHz
@@ -180,7 +180,7 @@ class TestPulseKernelEMG:
         sigma = 700000  # 700 us
         truncation_factor = 5
 
-        kernel = PulseProcessing.pulse_kernel_emg(ns, fs, t0, tau, sigma, truncation_factor)
+        kernel = PulseProcessing.pulse_kernel(ns, fs, t0, tau, sigma, truncation_factor)
 
         # Basic checks
         assert isinstance(kernel, np.ndarray)
@@ -196,7 +196,7 @@ class TestPulseKernelEMG:
         # Kernel should have finite values
         assert np.all(np.isfinite(kernel))
 
-    def test_pulse_kernel_emg_parameters(self):
+    def test_pulse_kernel_parameters(self):
         """Test pulse kernel with different parameter combinations."""
         ns = 5000
         fs = 50000  # 50 kHz
@@ -209,7 +209,7 @@ class TestPulseKernelEMG:
         ]
 
         for t0, tau, sigma, truncation_factor in test_params:
-            kernel = PulseProcessing.pulse_kernel_emg(ns, fs, t0, tau, sigma, truncation_factor)
+            kernel = PulseProcessing.pulse_kernel(ns, fs, t0, tau, sigma, truncation_factor)
 
             # Basic validation
             assert isinstance(kernel, np.ndarray)
@@ -219,7 +219,7 @@ class TestPulseKernelEMG:
             assert np.all(kernel >= 0)
             assert np.all(np.isfinite(kernel))
 
-    def test_pulse_kernel_emg_truncation(self):
+    def test_pulse_kernel_truncation(self):
         """Test that truncation factor affects kernel length appropriately."""
         ns = 10000
         fs = 100000
@@ -230,7 +230,7 @@ class TestPulseKernelEMG:
         # Test different truncation factors
         kernels = []
         for truncation_factor in [2, 5, 10]:
-            kernel = PulseProcessing.pulse_kernel_emg(ns, fs, t0, tau, sigma, truncation_factor)
+            kernel = PulseProcessing.pulse_kernel(ns, fs, t0, tau, sigma, truncation_factor)
             kernels.append(kernel)
 
             # All kernels should be normalized


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
- Set the correct default parameters regarding pulse kernel parameters.
- Placed the flipping of the pulse kernel, which was neglected in previous versions.
- Better defined `truncation_factor` by decoupling truncation length with `t0`.
- Removed EMG from all namings to avoid confusion.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
<img width="2023" height="1023" alt="image" src="https://github.com/user-attachments/assets/111f5e23-e8d6-4421-bf0d-8929f2ac9e20" />
<img width="698" height="568" alt="image" src="https://github.com/user-attachments/assets/2c4433e8-4ba3-46e4-af49-17dc32643376" />

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
