### PR TITLE
Hits (pulse bank)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Debugging
+.vscode/
+
 # Mac OS
 .DS_Store
 

--- a/straxion/plugins/__init__.py
+++ b/straxion/plugins/__init__.py
@@ -3,3 +3,6 @@ from .raw_records import *
 
 from . import records
 from .records import *
+
+from . import hits
+from .hits import *

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -307,15 +307,15 @@ class Hits(strax.Plugin):
                 # Align waveforms of the hits at the maximum of the moving averaged signal.
                 argmax_ma = np.argmax(
                     signal_ma[
-                        max(h_i - self.config["hit_window_length_left"], 0) : min(
-                            h_i + self.config["hit_window_length_right"], self.record_length
+                        max(h_i - self.hit_window_length_left, 0) : min(
+                            h_i + self.hit_window_length_right, self.record_length
                         )
                     ]
                 )
                 # For a physical hit, the left window is expected to be noise dominated.
                 # While the right window is expected to be signal dominated.
-                hit_wf_start_i = argmax_ma + hit_max_i - self.config["hit_window_length_left"]
-                hit_wf_end_i = argmax_ma + hit_max_i + self.config["hit_window_length_right"]
+                hit_wf_start_i = argmax_ma + hit_max_i - self.hit_window_length_left
+                hit_wf_end_i = argmax_ma + hit_max_i + self.hit_window_length_right
                 hits[i]["time"] = r["time"] + hit_wf_start_i * self.dt
                 hits[i]["endtime"] = r["time"] + hit_wf_end_i * self.dt
                 hits[i]["aligned_at_records_i"] = argmax_ma + hit_max_i

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -92,6 +92,24 @@ export, __all__ = strax.exporter()
     ),
 )
 class Hits(strax.Plugin):
+    """Find and characterize hits in processed phase angle data.
+
+    This plugin identifies significant signal excursions (hits) in processed phase angle
+    data and extracts their characteristics including amplitude, timing, and waveform
+    data. The hit-finding algorithm uses adaptive thresholds based on signal statistics
+    and applies various filtering criteria to distinguish real hits from noise.
+
+    Processing workflow:
+    1. Calculate adaptive hit thresholds based on signal statistics for each channel.
+    2. Identify hit candidates using threshold crossing and minimum width criteria.
+    3. Calculate hit characteristics (amplitude, timing, alignment point).
+    4. Extract and align hit waveforms for further analysis.
+
+    Provides:
+    - hits: Characterized hits with waveform data and timing information.
+
+    """
+
     __version__ = "0.0.0"
 
     # Inherited from straxen. Not optimized outside XENONnT.

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -302,23 +302,26 @@ class Hits(strax.Plugin):
                 hits[i]["amplitude_min"] = np.min(hit_inspection_waveform)
                 hits[i]["amplitude_max_ext"] = np.max(hit_extended_inspection_waveform)
                 hits[i]["amplitude_min_ext"] = np.min(hit_extended_inspection_waveform)
+
+                # Index of kernel-convolved signal in records.
                 hit_max_i = np.argmax(hit_inspection_waveform) + h_i
 
                 # Align waveforms of the hits at the maximum of the moving averaged signal.
                 argmax_ma = np.argmax(
                     signal_ma[
-                        max(h_i - self.hit_window_length_left, 0) : min(
-                            h_i + self.hit_window_length_right, self.record_length
+                        max(hit_max_i - self.hit_window_length_left, 0) : min(
+                            hit_max_i + self.hit_window_length_right, self.record_length
                         )
                     ]
                 )
+
                 # For a physical hit, the left window is expected to be noise dominated.
                 # While the right window is expected to be signal dominated.
-                hit_wf_start_i = argmax_ma + hit_max_i - self.hit_window_length_left
-                hit_wf_end_i = argmax_ma + hit_max_i + self.hit_window_length_right
+                hit_wf_start_i = max(argmax_ma - self.hit_window_length_left, 0)
+                hit_wf_end_i = min(argmax_ma + self.hit_window_length_right, self.record_length)
                 hits[i]["time"] = r["time"] + hit_wf_start_i * self.dt
                 hits[i]["endtime"] = r["time"] + hit_wf_end_i * self.dt
-                hits[i]["aligned_at_records_i"] = argmax_ma + hit_max_i
+                hits[i]["aligned_at_records_i"] = argmax_ma
                 hits[i]["data_theta"] = signal_raw[hit_wf_start_i:hit_wf_end_i]
                 hits[i]["data_theta_moving_average"] = signal_ma[hit_wf_start_i:hit_wf_end_i]
                 hits[i]["data_theta_convolved"] = signal[hit_wf_start_i:hit_wf_end_i]

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -2,6 +2,7 @@ import strax
 import numpy as np
 from straxion.utils import (
     DATA_DTYPE,
+    INDEX_DTYPE,
     SECOND_TO_NANOSECOND,
     base_waveform_dtype,
 )
@@ -128,7 +129,7 @@ class Hits(strax.Plugin):
                     ),
                     "width",
                 ),
-                np.int32,
+                INDEX_DTYPE,
             )
         )
         dtype.append(
@@ -182,7 +183,7 @@ class Hits(strax.Plugin):
         dtype.append(
             (
                 ("Index of alignment point (the maximum) in the records", "aligned_at_records_i"),
-                np.int32,
+                INDEX_DTYPE,
             )
         )
         dtype.append(

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -4,6 +4,8 @@ from straxion.utils import (
     DATA_DTYPE,
     INDEX_DTYPE,
     SECOND_TO_NANOSECOND,
+    HIT_WINDOW_LENGTH_LEFT,
+    HIT_WINDOW_LENGTH_RIGHT,
     base_waveform_dtype,
 )
 
@@ -56,20 +58,6 @@ export, __all__ = strax.exporter()
         ),
     ),
     strax.Option(
-        "hit_window_length_left",
-        default=40,
-        track=True,
-        type=int,
-        help="Length of the hit window extended to the left in unit of samples.",
-    ),
-    strax.Option(
-        "hit_window_length_right",
-        default=40,
-        track=True,
-        type=int,
-        help="Length of the hit window extended to the right in unit of samples.",
-    ),
-    strax.Option(
         "hit_inspection_window_length",
         default=60,
         track=True,
@@ -106,6 +94,9 @@ class Hits(strax.Plugin):
     save_when = strax.SaveWhen.ALWAYS
 
     def setup(self):
+        self.hit_window_length_left = HIT_WINDOW_LENGTH_LEFT
+        self.hit_window_length_right = HIT_WINDOW_LENGTH_RIGHT
+
         self.record_length = self.config["record_length"]
         self.dt = 1 / self.config["fs"] * SECOND_TO_NANOSECOND
 
@@ -115,9 +106,7 @@ class Hits(strax.Plugin):
         )
 
     def infer_dtype(self):
-        self.hit_waveform_length = (
-            self.config["hit_window_length_left"] + self.config["hit_window_length_right"]
-        )
+        self.hit_waveform_length = HIT_WINDOW_LENGTH_LEFT + HIT_WINDOW_LENGTH_RIGHT
 
         dtype = base_waveform_dtype()
         dtype.append(

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -273,10 +273,12 @@ class Hits(strax.Plugin):
                 continue
             # Find the start of the hits.
             _hits_width = np.diff(below_threshold_indices, prepend=0)
+            # Minimum continuous length of waveform above the hit threshold is
+            # required to define a hit.
             hit_start_indicies = below_threshold_indices[_hits_width >= min_pulse_width]
 
             hits = np.zeros(len(hit_start_indicies), dtype=self.infer_dtype())
-            hits_width = _hits_width[hit_start_indicies]
+            hits_width = _hits_width[_hits_width >= min_pulse_width]
             hits["width"] = hits_width
 
             # Find the maximum and minimum of the hits.

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -272,7 +272,7 @@ class Hits(strax.Plugin):
             if len(below_threshold_indices) == 0:
                 continue
             # Find the start of the hits.
-            _hits_width = np.diff(below_threshold_indices)
+            _hits_width = np.diff(below_threshold_indices, prepend=0)
             hit_start_indicies = below_threshold_indices[_hits_width >= min_pulse_width]
 
             hits = np.zeros(len(hit_start_indicies), dtype=self.infer_dtype())

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -272,11 +272,12 @@ class Hits(strax.Plugin):
             if len(below_threshold_indices) == 0:
                 continue
             # Find the start of the hits.
-            hits_width = np.diff(below_threshold_indices)
-            hit_start_indicies = below_threshold_indices[hits_width > min_pulse_width]
+            _hits_width = np.diff(below_threshold_indices)
+            hit_start_indicies = below_threshold_indices[_hits_width >= min_pulse_width]
 
             hits = np.zeros(len(hit_start_indicies), dtype=self.infer_dtype())
-            hits["width"] = hits_width[hit_start_indicies]
+            hits_width = _hits_width[hit_start_indicies]
+            hits["width"] = hits_width
 
             # Find the maximum and minimum of the hits.
             for i, h_i in enumerate(hit_start_indicies):

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -300,7 +300,6 @@ class Hits(strax.Plugin):
             for i, h_start_i in enumerate(hit_start_indicies):
                 hits[i]["hit_threshold"] = hit_threshold
                 hits[i]["channel"] = ch
-                hits[i]["length"] = self.hit_waveform_length
                 hits[i]["dt"] = self.dt
 
                 # Find the maximum and minimum of the hit in the inspection windows.
@@ -333,6 +332,7 @@ class Hits(strax.Plugin):
                         )
                     ]
                 ) + max(hit_max_i - self.hit_ma_inspection_window_length, 0)
+                hits[i]["aligned_at_records_i"] = argmax_ma_i
 
                 # For a physical hit, the left window is expected to be noise dominated.
                 # While the right window is expected to be signal dominated.
@@ -346,7 +346,6 @@ class Hits(strax.Plugin):
                 hits[i]["time"] = r["time"] + hit_wf_start_i * self.dt
                 hits[i]["endtime"] = r["time"] + hit_wf_end_i * self.dt
                 hits[i]["length"] = hit_wf_end_i - hit_wf_start_i
-                hits[i]["aligned_at_records_i"] = argmax_ma_i
                 hits[i]["data_theta"][
                     self.hit_window_length_left
                     - n_left_valid_samples : self.hit_window_length_left

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -224,6 +224,8 @@ class Hits(strax.Plugin):
             )
         )
 
+        return dtype
+
     @staticmethod
     def calculate_hit_threshold(signal, hit_threshold_sigma, noisy_channel_signal_std_multiplier):
         """Calculate hit threshold based on signal statistics.

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -16,6 +16,7 @@ export, __all__ = strax.exporter()
 @strax.takes_config(
     strax.Option(
         "record_length",
+        default=5_000_000,
         track=False,  # Not tracking record length, but we will have to check if it is as promised
         type=int,
         help=(

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -26,6 +26,7 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "fs",
+        default=50_000,
         track=True,
         type=int,
         help="Sampling frequency (assumed the same for all channels) in unit of Hz",
@@ -324,16 +325,13 @@ class Hits(strax.Plugin):
 
                 # Align waveforms of the hits at the maximum of the moving averaged signal.
                 # Search the maximum in the moving averaged signal within the inspection window.
-                argmax_ma_i = (
-                    np.argmax(
-                        signal_ma[
-                            max(hit_max_i - self.hit_ma_inspection_window_length, 0) : min(
-                                hit_max_i + self.hit_ma_inspection_window_length, self.record_length
-                            )
-                        ]
-                    )
-                    + hit_max_i
-                )
+                argmax_ma_i = np.argmax(
+                    signal_ma[
+                        max(hit_max_i - self.hit_ma_inspection_window_length, 0) : min(
+                            hit_max_i + self.hit_ma_inspection_window_length, self.record_length
+                        )
+                    ]
+                ) + max(hit_max_i - self.hit_ma_inspection_window_length, 0)
 
                 # For a physical hit, the left window is expected to be noise dominated.
                 # While the right window is expected to be signal dominated.

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -106,9 +106,6 @@ class Hits(strax.Plugin):
 
     def setup(self):
         self.record_length = self.config["record_length"]
-        self.hit_waveform_length = (
-            self.config["hit_window_length_left"] + self.config["hit_window_length_right"]
-        )
         self.dt = 1 / self.config["fs"] * SECOND_TO_NANOSECOND
 
         self.hit_thresholds_sigma = np.array(self.config["hit_thresholds_sigma"])
@@ -117,6 +114,10 @@ class Hits(strax.Plugin):
         )
 
     def infer_dtype(self):
+        self.hit_waveform_length = (
+            self.config["hit_window_length_left"] + self.config["hit_window_length_right"]
+        )
+
         dtype = base_waveform_dtype()
         dtype.append(
             (

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -290,10 +290,11 @@ class Hits(strax.Plugin):
             _hits_width = np.diff(below_threshold_indices, prepend=1)
             # Minimum continuous length of waveform above the hit threshold is
             # required to define a hit.
-            hit_start_indicies = below_threshold_indices[_hits_width >= min_pulse_width]
+            hit_end_indicies = below_threshold_indices[_hits_width >= min_pulse_width]
 
-            hits = np.zeros(len(hit_start_indicies), dtype=self.infer_dtype())
+            hits = np.zeros(len(hit_end_indicies), dtype=self.infer_dtype())
             hits_width = _hits_width[_hits_width >= min_pulse_width]
+            hit_start_indicies = hit_end_indicies - hits_width
             hits["width"] = hits_width
 
             # Find the maximum and minimum of the hits.

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -287,7 +287,7 @@ class Hits(strax.Plugin):
             if len(below_threshold_indices) == 0:
                 continue
             # Find the start of the hits.
-            _hits_width = np.diff(below_threshold_indices, prepend=0)
+            _hits_width = np.diff(below_threshold_indices, prepend=1)
             # Minimum continuous length of waveform above the hit threshold is
             # required to define a hit.
             hit_start_indicies = below_threshold_indices[_hits_width >= min_pulse_width]

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -295,7 +295,7 @@ class Hits(strax.Plugin):
             hits["width"] = hits_width
 
             # Find the maximum and minimum of the hits.
-            for i, h_i in enumerate(hit_start_indicies):
+            for i, h_start_i in enumerate(hit_start_indicies):
                 hits[i]["hit_threshold"] = hit_threshold
                 hits[i]["channel"] = ch
                 hits[i]["length"] = self.hit_waveform_length
@@ -303,14 +303,14 @@ class Hits(strax.Plugin):
 
                 # Find the maximum and minimum of the hit in the inspection windows.
                 hit_inspection_waveform = signal[
-                    h_i : min(
-                        h_i + self.config["hit_convolved_inspection_window_length"],
+                    h_start_i : min(
+                        h_start_i + self.config["hit_convolved_inspection_window_length"],
                         self.record_length,
                     )
                 ]
                 hit_extended_inspection_waveform = signal[
-                    h_i : min(
-                        h_i + self.config["hit_extended_inspection_window_length"],
+                    h_start_i : min(
+                        h_start_i + self.config["hit_extended_inspection_window_length"],
                         self.record_length,
                     )
                 ]
@@ -320,16 +320,20 @@ class Hits(strax.Plugin):
                 hits[i]["amplitude_min_ext"] = np.min(hit_extended_inspection_waveform)
 
                 # Index of kernel-convolved signal in records.
-                hit_max_i = np.argmax(hit_inspection_waveform) + h_i
+                hit_max_i = np.argmax(hit_inspection_waveform) + h_start_i
 
                 # Align waveforms of the hits at the maximum of the moving averaged signal.
-                argmax_ma_i = np.argmax(
-                    signal_ma[
-                        max(hit_max_i - self.hit_ma_inspection_window_length, 0) : min(
-                            hit_max_i + self.hit_ma_inspection_window_length, self.record_length
-                        )
-                    ]
-                ) + max(hit_max_i - self.hit_window_length_left, 0)
+                # Search the maximum in the moving averaged signal within the inspection window.
+                argmax_ma_i = (
+                    np.argmax(
+                        signal_ma[
+                            max(hit_max_i - self.hit_ma_inspection_window_length, 0) : min(
+                                hit_max_i + self.hit_ma_inspection_window_length, self.record_length
+                            )
+                        ]
+                    )
+                    + hit_max_i
+                )
 
                 # For a physical hit, the left window is expected to be noise dominated.
                 # While the right window is expected to be signal dominated.

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -120,10 +120,15 @@ class Hits(strax.Plugin):
         dtype = base_waveform_dtype()
         dtype.append(
             (
-                "Width of the hit waveform (length above the hit threshold) in unit of samples.",
-                "width",
-            ),
-            np.int32,
+                (
+                    (
+                        "Width of the hit waveform (length above the hit threshold) "
+                        "in unit of samples.",
+                    ),
+                    "width",
+                ),
+                np.int32,
+            )
         )
         dtype.append(
             (
@@ -166,48 +171,66 @@ class Hits(strax.Plugin):
         )
         dtype.append(
             (
-                "Hit finding threshold determined by signal statistics in unit of rad.",
-                "hit_threshold",
-            ),
-            DATA_DTYPE,
-        )
-        dtype.append(
-            ("Index of alignment point (the maximum) in the records", "aligned_at_records_i"),
-            np.int32,
-        )
-        dtype.append(
-            (
-                "Maximum amplitude of the hit waveform (within the hit window) in unit of rad.",
-                "amplitude_max",
-            ),
-            DATA_DTYPE,
+                (
+                    "Hit finding threshold determined by signal statistics in unit of rad.",
+                    "hit_threshold",
+                ),
+                DATA_DTYPE,
+            )
         )
         dtype.append(
             (
-                "Minimum amplitude of the hit waveform (within the hit window) in unit of rad.",
-                "amplitude_min",
-            ),
-            DATA_DTYPE,
+                ("Index of alignment point (the maximum) in the records", "aligned_at_records_i"),
+                np.int32,
+            )
         )
         dtype.append(
             (
                 (
-                    "Maximum amplitude of the hit waveform (within the extended hit window) "
-                    "in unit of rad.",
+                    (
+                        "Maximum amplitude of the hit waveform (within the hit window) "
+                        "in unit of rad.",
+                    ),
+                    "amplitude_max",
                 ),
-                "amplitude_max_ext",
-            ),
-            DATA_DTYPE,
+                DATA_DTYPE,
+            )
         )
         dtype.append(
             (
                 (
-                    "Minimum amplitude of the hit waveform (within the extended hit window) "
-                    "in unit of rad.",
+                    (
+                        "Minimum amplitude of the hit waveform (within the hit window) "
+                        "in unit of rad.",
+                    ),
+                    "amplitude_min",
                 ),
-                "amplitude_min_ext",
-            ),
-            DATA_DTYPE,
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    (
+                        "Maximum amplitude of the hit waveform (within the extended hit window) "
+                        "in unit of rad.",
+                    ),
+                    "amplitude_max_ext",
+                ),
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    (
+                        "Minimum amplitude of the hit waveform (within the extended hit window) "
+                        "in unit of rad.",
+                    ),
+                    "amplitude_min_ext",
+                ),
+                DATA_DTYPE,
+            )
         )
 
     @staticmethod

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -1,0 +1,113 @@
+import strax
+import numpy as np
+
+export, __all__ = strax.exporter()
+
+
+@export
+@strax.takes_config(
+    strax.Option(
+        "hit_thresholds_sigma",
+        default=[3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+        track=True,
+        type=list,
+        help="Threshold for hit finding in units of sigma of standard deviation of the noise.",
+    ),
+    strax.Option(
+        "noisy_channel_signal_std_multipliers",
+        default=[2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+        track=True,
+        type=list,
+        help=(
+            "If the signal standard deviation above this threshold times of signal absolute "
+            "mean, the signal is considered noisy and the hit threshold is increased."
+        ),
+    ),
+    strax.Option(
+        "min_pulse_widths_samples",
+        default=[20, 20, 20, 20, 20, 20, 20, 20, 20, 20],
+        track=True,
+        type=list,
+        help=(
+            "Minimum pulse width in unit of samples. If the pulse width is below this "
+            "threshold, the hit is not considered a new hit."
+        ),
+    ),
+    strax.Option(
+        "hit_window_length_left",
+        default=100,
+        track=True,
+        type=int,
+        help="Length of the hit window in unit of samples.",
+    ),
+)
+class Hits(strax.Plugin):
+    __version__ = "0.0.0"
+    rechunk_on_save = False
+    compressor = "zstd"  # Inherited from straxen. Not optimized outside XENONnT.
+
+    depends_on = ["records"]
+    provides = "hits"
+    data_kind = "hits"
+    save_when = strax.SaveWhen.ALWAYS
+
+    chunk_target_size_mb = 2000
+    rechunk_on_load = True
+    chunk_source_size_mb = 100
+
+    def setup(self):
+        self.hit_thresholds_sigma = np.array(self.config["hit_thresholds_sigma"])
+        self.noisy_channel_signal_std_multipliers = np.array(
+            self.config["noisy_channel_signal_std_multipliers"]
+        )
+
+    def infer_dtype(self):
+        pass
+
+    @staticmethod
+    def calculate_hit_threshold(signal, hit_threshold_sigma, noisy_channel_signal_std_multiplier):
+        """Calculate hit threshold based on signal statistics.
+
+        Args:
+            signal (np.ndarray): The signal array to analyze.
+            hit_threshold_sigma (float): Threshold multiplier in units of sigma.
+            noisy_channel_signal_std_multiplier (float): Multiplier to detect noisy channels.
+
+        Returns:
+            float: The calculated hit threshold.
+
+        """
+        signal_mean = np.mean(signal)
+        signal_abs_mean = np.mean(np.abs(signal))
+        signal_std = np.std(signal)
+
+        # The naive hit threshold is a multiple of the standard deviation of the signal.
+        hit_threshold = signal_mean + hit_threshold_sigma * signal_std
+
+        # If the signal is noisy, the baseline might be too high.
+        if signal_std > noisy_channel_signal_std_multiplier * signal_abs_mean:
+            # We will use the quiet part of the signal to redefine a lowered hit threshold.
+            quiet_mask = signal < hit_threshold
+            hit_threshold = signal_mean + hit_threshold_sigma * np.std(signal[quiet_mask])
+
+        return hit_threshold
+
+    def compute(self, records):
+        for r in records:
+            ch = int(r["channel"])
+            signal = r["data_theta_convolved"]
+            min_pulse_width = self.config["min_pulse_widths_samples"][ch]
+
+            hit_threshold = self.calculate_hit_threshold(
+                signal, self.hit_thresholds_sigma[ch], self.noisy_channel_signal_std_multipliers[ch]
+            )
+
+            below_threshold_indices = np.where(signal < hit_threshold)[0]
+            if len(below_threshold_indices) == 0:
+                continue
+            # Find the start of the hits.
+            hit_start_indicies = below_threshold_indices[
+                np.diff(below_threshold_indices) > min_pulse_width
+            ]
+
+            hit_start_indicies

--- a/straxion/plugins/raw_records.py
+++ b/straxion/plugins/raw_records.py
@@ -29,7 +29,7 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "fs",
-        default=500_000,
+        default=50_000,
         track=True,
         type=int,
         help="Sampling frequency (assumed the same for all channels) in unit of Hz",

--- a/straxion/plugins/raw_records.py
+++ b/straxion/plugins/raw_records.py
@@ -95,7 +95,7 @@ class DAQReader(strax.Plugin):
 
     def infer_dtype(self):
         """Data type for a waveform raw_record."""
-        dtype = base_waveform_dtype(self.config["record_length"])
+        dtype = base_waveform_dtype()
         dtype.append(
             (
                 ("Waveform data of I in raw ADC counts", "data_i"),

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -31,21 +31,21 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "pulse_kernel_start_time",
-        default=40_000,
+        default=200_000,
         track=True,
         type=int,
         help="Relative start time of the exponential decay in pulse kernel (t0), in unit of ns.",
     ),
     strax.Option(
         "pulse_kernel_decay_time",
-        default=120_000,
+        default=600_000,
         track=True,
         type=int,
         help="Decay time of the exponential falling in pulse kernel (tau), in unit of ns.",
     ),
     strax.Option(
         "pulse_kernel_gaussian_smearing_width",
-        default=56_000,
+        default=28_000,
         track=True,
         type=int,
         help=(

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -44,7 +44,7 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "pulse_kernel_gaussian_smearing_width",
-        default=14_000,  # The original Matlab code says 7 samples (with fs = 1E5Hz).
+        default=140_000,  # The original Matlab code says 7 samples (with fs = 5E4Hz).
         track=True,
         type=int,
         help=(
@@ -54,7 +54,7 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "moving_average_width",
-        default=500_000,  # The original Matlab code says 5 samples (with fs = 1E5Hz).
+        default=50_000,  # The original Matlab code says 5 samples (with fs = 5E4Hz).
         track=True,
         type=int,
         help="Moving average width for smoothed reference waveform, in unit of ns.",
@@ -172,7 +172,7 @@ class PulseProcessing(strax.Plugin):
         )
 
         # Pre-compute moving average kernel.
-        moving_average_kernel_width = int(self.config["moving_average_width"] / self.dt)
+        moving_average_kernel_width = self.config["moving_average_width"] / self.dt
         self.moving_average_kernel = (
             np.ones(moving_average_kernel_width) / moving_average_kernel_width
         )

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -115,7 +115,7 @@ class PulseProcessing(strax.Plugin):
             raw_records_dtype = self.deps["raw_records"].dtype_for("raw_records")
             record_length = len(np.zeros(1, raw_records_dtype)[0]["data_i"])
 
-        dtype = base_waveform_dtype(record_length)
+        dtype = base_waveform_dtype()
         dtype.append(
             (
                 (

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -24,27 +24,28 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "fs",
+        default=50_000,
         track=True,
         type=int,
         help="Sampling frequency (assumed the same for all channels) in unit of Hz",
     ),
     strax.Option(
         "pulse_kernel_start_time",
-        default=100_000,
+        default=40_000,
         track=True,
         type=int,
         help="Relative start time of the exponential decay in pulse kernel (t0), in unit of ns.",
     ),
     strax.Option(
         "pulse_kernel_decay_time",
-        default=300_000,
+        default=120_000,
         track=True,
         type=int,
         help="Decay time of the exponential falling in pulse kernel (tau), in unit of ns.",
     ),
     strax.Option(
         "pulse_kernel_gaussian_smearing_width",
-        default=140_000,  # The original Matlab code says 7 samples (with fs = 5E4Hz).
+        default=56_000,
         track=True,
         type=int,
         help=(
@@ -54,7 +55,7 @@ export, __all__ = strax.exporter()
     ),
     strax.Option(
         "moving_average_width",
-        default=50_000,  # The original Matlab code says 5 samples (with fs = 5E4Hz).
+        default=100_000,  # The original Matlab code says 5 samples (with fs = 5E4Hz).
         track=True,
         type=int,
         help="Moving average width for smoothed reference waveform, in unit of ns.",
@@ -172,7 +173,7 @@ class PulseProcessing(strax.Plugin):
         )
 
         # Pre-compute moving average kernel.
-        moving_average_kernel_width = self.config["moving_average_width"] / self.dt
+        moving_average_kernel_width = int(self.config["moving_average_width"] / self.dt)
         self.moving_average_kernel = (
             np.ones(moving_average_kernel_width) / moving_average_kernel_width
         )

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -119,7 +119,7 @@ class PulseProcessing(strax.Plugin):
         dtype.append(
             (
                 (
-                    ("Waveform data of phase angle (theta) after baseline corrections",),
+                    "Waveform data of phase angle (theta) after baseline corrections",
                     "data_theta",
                 ),
                 DATA_DTYPE,

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -119,10 +119,7 @@ class PulseProcessing(strax.Plugin):
         dtype.append(
             (
                 (
-                    (
-                        "Waveform data of phase angle (theta), "
-                        "which has been convoled by a pulse kernel."
-                    ),
+                    ("Waveform data of phase angle (theta) after baseline corrections",),
                     "data_theta",
                 ),
                 DATA_DTYPE,

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -10,11 +10,8 @@ CHANNEL_DTYPE = np.int16
 DATA_DTYPE = np.dtype(">f8")
 
 
-def base_waveform_dtype(record_length):
+def base_waveform_dtype():
     """Return the base dtype list for a waveform record, without the data fields.
-
-    Args:
-        record_length (int): Number of samples in each dataset.
 
     Returns:
         list: List of dtype tuples for the base waveform record fields.

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -10,9 +10,9 @@ CHANNEL_DTYPE = np.int16
 DATA_DTYPE = np.dtype("f8")
 INDEX_DTYPE = np.int32
 
-# Hit window length.
-HIT_WINDOW_LENGTH_LEFT = 40
-HIT_WINDOW_LENGTH_RIGHT = 40
+# Hit waveform recording window length.
+HIT_WINDOW_LENGTH_LEFT = 300
+HIT_WINDOW_LENGTH_RIGHT = 300
 
 
 def base_waveform_dtype():

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -8,6 +8,7 @@ TIME_DTYPE = np.int64
 LENGTH_DTYPE = np.int64
 CHANNEL_DTYPE = np.int16
 DATA_DTYPE = np.dtype(">f8")
+INDEX_DTYPE = np.int32
 
 
 def base_waveform_dtype():

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -7,7 +7,7 @@ SECOND_TO_NANOSECOND = 1_000_000_000
 TIME_DTYPE = np.int64
 LENGTH_DTYPE = np.int64
 CHANNEL_DTYPE = np.int16
-DATA_DTYPE = np.dtype(">f8")
+DATA_DTYPE = np.dtype("f8")
 INDEX_DTYPE = np.int32
 
 # Hit window length.

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -10,6 +10,10 @@ CHANNEL_DTYPE = np.int16
 DATA_DTYPE = np.dtype(">f8")
 INDEX_DTYPE = np.int32
 
+# Hit window length.
+HIT_WINDOW_LENGTH_LEFT = 40
+HIT_WINDOW_LENGTH_RIGHT = 40
+
 
 def base_waveform_dtype():
     """Return the base dtype list for a waveform record, without the data fields.


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

- Implemented `hits`, which is also known as "pulse banks". 
- The cosmic ray identification functionalities have been decoupled from `hits`, and will be in `hits_classification` and `cut_symmetric_spikes`.
- The hit waveforms are aligned at the maximum of `data_theta_convolved`.
- Minor tweaks for other plugins.
- Make default paramters based on `timeS429` test dataset.

## Can you briefly describe how it works?

As the first version of implementation of `hits` or the pulse bank, this PR is mostly a direct translation from [the Matlab code](https://github.com/FaroutYLq/axioph/tree/main/QUALIPHIDE/old_matlab).

Some proof of concept plots can be made from notebook [here](https://github.com/FaroutYLq/axioph/blob/main/QUALIPHIDE/debug_straxion/debug_hits.ipynb).

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

## Discussions

They should be fixed in the long term, but are beyond the scope of this PR. They could be issues to add:

- When a hit is long enough to extend beyond `hit_window_length_right`, we will have truncated hit waveforms.
- If multiple hits are piled up in the `hit_window_length_*`, we will have a `hit` including multiple physical hits. This can be resolved by finer hit splitting, like what is done in `strax.find_hits`.
- There is a time shift between `data_theta_moving_average` and `data_theta_convolved` due to non-zero `t0`. It is expected that the current hit finding algorithm might have different behaviors under variant `t0`. Shall we set warning or a safety check on the range of `t0`?
- We need to figure out whether interpreting `data_theta_convolved`, instead of the raw one (`data_theta`) as `signal` is the best option in the analysis workflow.
- Waveform features (ranges, rise time) can be added to `hits`, after carefully treating long hit and pile-up.

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
