### PR TITLE
Downgrade DATA_DTYPE to f4

### DIFF
--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -232,7 +232,7 @@ class PulseProcessing(strax.Plugin):
                 continue
             channel = int(m.group(1))
             try:
-                arr = np.loadtxt(f, delimiter=None)  # Use autodetect delimiter.
+                arr = np.loadtxt(f, delimiter=None, dtype=DATA_DTYPE)  # Use autodetect delimiter.
             except Exception as e:
                 raise RuntimeError(f"Failed to load fine scan file {f}: {e}")
             if arr.ndim == 1:

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -7,7 +7,7 @@ SECOND_TO_NANOSECOND = 1_000_000_000
 TIME_DTYPE = np.int64
 LENGTH_DTYPE = np.int64
 CHANNEL_DTYPE = np.int16
-DATA_DTYPE = np.dtype("f8")
+DATA_DTYPE = np.dtype("f4")
 INDEX_DTYPE = np.int32
 
 # Hit waveform recording window length.

--- a/tests/run_test_example.py
+++ b/tests/run_test_example.py
@@ -48,8 +48,8 @@ def test_raw_records_processing(data_dir):
         # Check data types
         assert rr["time"].dtype == np.int64
         assert rr["channel"].dtype == np.int16
-        assert rr["data_i"].dtype == np.dtype(">f8")
-        assert rr["data_q"].dtype == np.dtype(">f8")
+        assert rr["data_i"].dtype == np.float32
+        assert rr["data_q"].dtype == np.float32
         print("✓ Data types are correct")
 
         # Check that all records have the expected length

--- a/tests/test_raw_records.py
+++ b/tests/test_raw_records.py
@@ -106,8 +106,8 @@ def test_raw_records_processing():
         # Check data types
         assert rr["time"].dtype == np.int64
         assert rr["channel"].dtype == np.int16
-        assert rr["data_i"].dtype == np.float64
-        assert rr["data_q"].dtype == np.float64
+        assert rr["data_i"].dtype == np.float32
+        assert rr["data_q"].dtype == np.float32
 
         # Check that all records have the expected length
         expected_length = config["record_length"]

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -365,7 +365,7 @@ class TestLoadFinescanFilesWithRealData:
 
             # Check data integrity
             assert np.all(np.isfinite(data))
-            assert data.dtype == np.float64
+            assert data.dtype == np.float32
 
         print(f"Successfully loaded finescan data for {len(result)} channels")
 
@@ -463,11 +463,11 @@ class TestLoadFinescanFilesWithRealData:
             assert r["length"].dtype == np.int64
             assert r["dt"].dtype == np.int64
             assert r["channel"].dtype == np.int16
-            assert r["data_theta"].dtype == np.float64
-            assert r["data_theta_moving_average"].dtype == np.float64
-            assert r["data_theta_convolved"].dtype == np.float64
-            assert r["baseline"].dtype == np.float64
-            assert r["baseline_std"].dtype == np.float64
+            assert r["data_theta"].dtype == np.float32
+            assert r["data_theta_moving_average"].dtype == np.float32
+            assert r["data_theta_convolved"].dtype == np.float32
+            assert r["baseline"].dtype == np.float32
+            assert r["baseline_std"].dtype == np.float32
 
             # Check that all records have the expected length
             expected_length = config["record_length"]


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
As reported in #12, the debugger is extremely slow because of the heavy `__repr__` of `np.float64`. Now we downgraded `DATA_DTYPE` to `np.float("f4")`. 

## Can you briefly describe how it works?
Now we downgraded `DATA_DTYPE` to `np.float("f4")`. 

## Can you give a minimal working example (or illustrate with a figure)?
Tried in debugger, and the speed is exponentially faster. It is now debuggable. 

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
