### PR TITLE
Hit classification

### DIFF
--- a/straxion/plugins/__init__.py
+++ b/straxion/plugins/__init__.py
@@ -6,3 +6,6 @@ from .records import *
 
 from . import hits
 from .hits import *
+
+from . import hit_classification
+from .hit_classification import *

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -159,7 +159,7 @@ class HitClassification(strax.Plugin):
 
     def is_symmetric_spike_hit(self, hits, hit_classification):
         self.compute_ma_rise_edge_slope(hits, hit_classification)
-        hits["is_symmetric_spike"] = (
+        hit_classification["is_symmetric_spike"] = (
             hit_classification["ma_rise_edge_slope"] > self.ss_min_slope[hits["channel"]]
         )
 

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -148,11 +148,11 @@ class HitClassification(strax.Plugin):
 
         """
         mask_convolved = hits["amplitude_convolved_max"] >= hits["hit_threshold"]
-        mask_convolved &= hits["amplitude_convolved_max"] >= (
+        mask_convolved &= hits["amplitude_convolved_max_ext"] >= (
             hits["record_convolved_std"] * self.cr_convolved_std_coeff[hits["channel"]]
         )
-        mask_ma = hits["amplitude_ma_max"] >= self.cr_min_ma_amplitude[hits["channel"]]
-        mask_ma |= hits["amplitude_ma_max"] >= (
+        mask_ma = hits["amplitude_ma_max_ext"] >= self.cr_min_ma_amplitude[hits["channel"]]
+        mask_ma |= hits["amplitude_ma_max_ext"] >= (
             hits["record_ma_mean"] + hits["record_ma_std"] * self.cr_ma_std_coeff[hits["channel"]]
         )
         hit_classification["is_cr"] = mask_convolved | mask_ma

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -157,8 +157,8 @@ class HitClassification(strax.Plugin):
         )
         hit_classification["is_cr"] = mask_convolved | mask_ma
 
-    def is_symmetric_spike_hit(self, hits):
-        self.compute_ma_rise_edge_slope(hits)
+    def is_symmetric_spike_hit(self, hits, hit_classification):
+        self.compute_ma_rise_edge_slope(hits, hit_classification)
         hits["is_symmetric_spike"] = hits["ma_rise_edge_slope"] > self.ss_min_slope[hits["channel"]]
 
     def compute(self, hits):

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -163,6 +163,9 @@ class HitClassification(strax.Plugin):
 
     def compute(self, hits):
         hit_classification = np.zeros(len(hits), dtype=self.infer_dtype())
+
         self.is_unidentified_hit(hits, hit_classification)
         self.is_cr_hit(hits, hit_classification)
         self.is_symmetric_spike_hit(hits, hit_classification)
+
+        return hit_classification

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -159,7 +159,9 @@ class HitClassification(strax.Plugin):
 
     def is_symmetric_spike_hit(self, hits, hit_classification):
         self.compute_ma_rise_edge_slope(hits, hit_classification)
-        hits["is_symmetric_spike"] = hits["ma_rise_edge_slope"] > self.ss_min_slope[hits["channel"]]
+        hits["is_symmetric_spike"] = (
+            hit_classification["ma_rise_edge_slope"] > self.ss_min_slope[hits["channel"]]
+        )
 
     def compute(self, hits):
         hit_classification = np.zeros(len(hits), dtype=self.infer_dtype())

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -1,0 +1,85 @@
+import strax
+import numpy as np
+from straxion.utils import TIME_DTYPE, CHANNEL_DTYPE
+
+export, __all__ = strax.exporter()
+
+
+@export
+@strax.takes_config(
+    strax.Option(
+        "cr_ma_std_coeff",
+        type=np.float32,
+        default=20.0,
+        help=(
+            "Coefficients applied to the moving averaged signal's "
+            "standard deviation for identifying cosmic ray hits."
+        ),
+    ),
+    strax.Option(
+        "cr_convolved_std_coeff",
+        type=np.float32,
+        default=20.0,
+        help=(
+            "Coefficients applied to the convolved signal's "
+            "standard deviation for identifying cosmic ray hits."
+        ),
+    ),
+    strax.Option(
+        "cr_min_ma_amplitude",
+        type=np.float32,
+        default=1.0,
+        help=(
+            "Minimum amplitude of the moving averaged signal's " "for identifying cosmic ray hits."
+        ),
+    ),
+)
+class HitClassification(strax.Plugin):
+    """Classify hits into different types based on their characteristics."""
+
+    __version__ = "0.0.0"
+
+    depends_on = "hits"
+    provides = "hit_classification"
+    data_kind = "hits"
+    save_when = strax.SaveWhen.ALWAYS
+
+    def setup(self):
+        self.cr_ma_std_coeff = self.config["cr_ma_std_coeff"]
+        self.cr_convolved_std_coeff = self.config["cr_convolved_std_coeff"]
+        self.cr_min_ma_amplitude = self.config["cr_min_ma_amplitude"]
+
+    def infer_dtype(self):
+        base_dtype = [
+            (("Start time since unix epoch [ns]", "time"), TIME_DTYPE),
+            (("Exclusive end time since unix epoch [ns]", "endtime"), TIME_DTYPE),
+            (("Channel number defined by channel_map", "channel"), CHANNEL_DTYPE),
+        ]
+
+        hit_id_dtype = [
+            (("Is identified as cosmic ray hit", "is_cr"), bool),
+            (("Is identified as symmetric spike hit", "is_symmetric_spike"), bool),
+            (("Is unidentified hit", "is_unidentified"), bool),
+        ]
+
+        return base_dtype + hit_id_dtype
+
+    def is_unidentified_hit(self, hits):
+        hits["is_unidentified"] = hits["amplitude_convolved_max"] < hits["hit_threshold"]
+
+    def is_cr_hit(self, hits):
+        mask = hits["amplitude_convolved_max"] >= hits["hit_threshold"]
+        mask &= hits["amplitude_convolved_max"] >= (
+            hits["record_convolved_std"] * self.cr_convolved_std_coeff
+        )
+        mask |= (hits["amplitude_ma_max"] >= self.cr_min_ma_amplitude) & (
+            hits["amplitude_ma_max"]
+            >= (hits["record_ma_mean"] + hits["record_ma_std"] * self.cr_ma_std_coeff)
+        )
+        hits["is_cr"] = mask | hits["is_unidentified"]
+
+    def is_symmetric_spike_hit(self, hits):
+        pass
+
+    def compute(self, hits):
+        pass

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -165,6 +165,9 @@ class HitClassification(strax.Plugin):
 
     def compute(self, hits):
         hit_classification = np.zeros(len(hits), dtype=self.infer_dtype())
+        hit_classification["time"] = hits["time"]
+        hit_classification["endtime"] = hits["endtime"]
+        hit_classification["channel"] = hits["channel"]
 
         self.is_unidentified_hit(hits, hit_classification)
         self.is_cr_hit(hits, hit_classification)

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -152,7 +152,7 @@ class HitClassification(strax.Plugin):
             hits["record_convolved_std"] * self.cr_convolved_std_coeff[hits["channel"]]
         )
         mask_ma = hits["amplitude_ma_max"] >= self.cr_min_ma_amplitude[hits["channel"]]
-        mask_ma &= hits["amplitude_ma_max"] >= (
+        mask_ma |= hits["amplitude_ma_max"] >= (
             hits["record_ma_mean"] + hits["record_ma_std"] * self.cr_ma_std_coeff[hits["channel"]]
         )
         hit_classification["is_cr"] = mask_convolved | mask_ma

--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -160,7 +160,7 @@ class HitClassification(strax.Plugin):
     def is_symmetric_spike_hit(self, hits, hit_classification):
         self.compute_ma_rise_edge_slope(hits, hit_classification)
         hit_classification["is_symmetric_spike"] = (
-            hit_classification["ma_rise_edge_slope"] > self.ss_min_slope[hits["channel"]]
+            hit_classification["ma_rise_edge_slope"] < self.ss_min_slope[hits["channel"]]
         )
 
     def compute(self, hits):

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -521,6 +521,7 @@ class Hits(strax.Plugin):
             hit: The hit array element to populate.
             hit_start_i: Start index of the hit.
             signal: The convolved signal array.
+            signal_ma: The moving average signal array.
 
         """
         hit_end_i = min(
@@ -533,8 +534,8 @@ class Hits(strax.Plugin):
         )
         # Find the maximum and minimum of the hit in the inspection windows
         hit_convolved_inspection_waveform = signal[hit_start_i:hit_end_i]
-        hit_convolved_extended_inspection_waveform = signal[hit_start_i:hit_end_i]
-        hit_ma_inspection_waveform = signal_ma[hit_start_i:hit_extended_end_i]
+        hit_convolved_extended_inspection_waveform = signal[hit_start_i:hit_extended_end_i]
+        hit_ma_inspection_waveform = signal_ma[hit_start_i:hit_end_i]
         hit_ma_extended_inspection_waveform = signal_ma[hit_start_i:hit_extended_end_i]
 
         hit["amplitude_convolved_max"] = np.max(hit_convolved_inspection_waveform)

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -337,6 +337,60 @@ class Hits(strax.Plugin):
                 DATA_DTYPE,
             )
         )
+        dtype.append(
+            (
+                (
+                    "Mean of the convolved signal in the record.",
+                    "record_convolved_mean",
+                ),
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    "Standard deviation of the convolved signal in the record.",
+                    "record_convolved_std",
+                ),
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    "Mean of the moving averaged signal in the record.",
+                    "record_ma_mean",
+                ),
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    "Standard deviation of the moving averaged signal in the record.",
+                    "record_ma_std",
+                ),
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    "Mean of the raw signal in the record.",
+                    "record_raw_mean",
+                ),
+                DATA_DTYPE,
+            )
+        )
+        dtype.append(
+            (
+                (
+                    "Standard deviation of the raw signal in the record.",
+                    "record_raw_std",
+                ),
+                DATA_DTYPE,
+            )
+        )
 
         return dtype
 
@@ -423,6 +477,13 @@ class Hits(strax.Plugin):
         hits = self._process_hit_candidates(
             hit_candidates, record, signal, signal_ma, signal_raw, hit_threshold, ch
         )
+
+        hits["record_raw_mean"] = np.mean(signal_raw)
+        hits["record_raw_std"] = np.std(signal_raw)
+        hits["record_convolved_std"] = np.std(signal)
+        hits["record_convolved_mean"] = np.mean(signal)
+        hits["record_ma_mean"] = np.mean(signal_ma)
+        hits["record_ma_std"] = np.std(signal_ma)
 
         return hits
 

--- a/straxion/plugins/hits.py
+++ b/straxion/plugins/hits.py
@@ -505,7 +505,7 @@ class Hits(strax.Plugin):
         hit["dt"] = self.dt
 
         # Calculate amplitude characteristics
-        self._calculate_hit_amplitudes(hit, hit_start_i, signal)
+        self._calculate_hit_amplitudes(hit, hit_start_i, signal, signal_ma)
 
         # Find alignment point and extract waveforms
         aligned_index = self._find_alignment_point(hit_start_i, signal, signal_ma)

--- a/tests/run_test_example.py
+++ b/tests/run_test_example.py
@@ -27,7 +27,7 @@ def test_raw_records_processing(data_dir):
     # Create context and process raw_records
     st = straxion.qualiphide()
 
-    config = {"daq_input_dir": data_dir, "record_length": 5_000_000, "fs": 500_000}
+    config = {"daq_input_dir": data_dir, "record_length": 5_000_000, "fs": 50_000}
 
     try:
         print("Processing raw_records...")

--- a/tests/test_hit_classification.py
+++ b/tests/test_hit_classification.py
@@ -61,14 +61,7 @@ def test_hit_classification_processing():
 
     # Create context and process hit classification
     st = straxion.qualiphide()
-    st.set_config(
-        dict(
-            daq_input_dir=test_data_dir,
-            iq_finescan_dir=finescan_data_dir,
-            record_length=5_000_000,
-            fs=500_000,
-        )
-    )
+    st.set_config(dict(daq_input_dir=test_data_dir, iq_finescan_dir=finescan_data_dir))
 
     try:
         hit_classification = st.get_array("timeS429", "hit_classification")

--- a/tests/test_hit_classification.py
+++ b/tests/test_hit_classification.py
@@ -130,8 +130,8 @@ def test_hit_classification_processing():
                 f"{n_unidentified} unidentified"
             )
 
-            assert n_cr == 60, "Expected 60 cosmic rays, got {}".format(n_cr)
-            assert n_unidentified == 0, "Expected 0 unidentified hits, got {}".format(
+            assert int(n_cr) == 60, "Expected 60 cosmic rays, got {}".format(n_cr)
+            assert int(n_unidentified) == 0, "Expected 0 unidentified hits, got {}".format(
                 n_unidentified
             )
 

--- a/tests/test_hit_classification.py
+++ b/tests/test_hit_classification.py
@@ -1,0 +1,139 @@
+import os
+import pytest
+import numpy as np
+import straxion
+from straxion.plugins.hit_classification import HitClassification
+
+
+def test_hit_classification_plugin_registration():
+    """Test that the HitClassification plugin is properly registered in the context."""
+    st = straxion.qualiphide()
+    assert "hit_classification" in st._plugin_class_registry
+    assert st._plugin_class_registry["hit_classification"] == HitClassification
+
+
+def test_hit_classification_dtype_inference():
+    """Test that HitClassification can infer the correct data type."""
+    st = straxion.qualiphide()
+    plugin = st.get_single_plugin("timeS429", "hit_classification")
+    dtype = plugin.infer_dtype()
+    # List of expected fields
+    expected_fields = [
+        "time",
+        "endtime",
+        "channel",
+        "is_cr",
+        "is_symmetric_spike",
+        "is_unidentified",
+        "ma_rise_edge_slope",
+    ]
+    field_names = [name[1] for name, *_ in dtype]
+    for field in expected_fields:
+        assert field in field_names
+
+
+@pytest.mark.skipif(
+    not os.getenv("STRAXION_TEST_DATA_DIR") or not os.getenv("STRAXION_FINESCAN_DATA_DIR"),
+    reason=(
+        "Finescan test data directory not provided via "
+        "STRAXION_FINESCAN_DATA_DIR environment variable"
+    ),
+)
+def test_hit_classification_processing():
+    """Test the complete hit classification processing pipeline with real data.
+
+    This test requires both STRAXION_TEST_DATA_DIR and STRAXION_FINESCAN_DATA_DIR environment
+    variables to be set to the paths containing the test data directories.
+
+    """
+    test_data_dir = os.getenv("STRAXION_TEST_DATA_DIR")
+    finescan_data_dir = os.getenv("STRAXION_FINESCAN_DATA_DIR")
+
+    if not test_data_dir:
+        pytest.fail("STRAXION_TEST_DATA_DIR environment variable is not set")
+    if not finescan_data_dir:
+        pytest.fail("STRAXION_FINESCAN_DATA_DIR environment variable is not set")
+
+    if not os.path.exists(test_data_dir):
+        pytest.fail(f"Test data directory {test_data_dir} does not exist")
+    if not os.path.exists(finescan_data_dir):
+        pytest.fail(f"Finescan data directory {finescan_data_dir} does not exist")
+
+    # Create context and process hit classification
+    st = straxion.qualiphide()
+    st.set_config(
+        dict(
+            daq_input_dir=test_data_dir,
+            iq_finescan_dir=finescan_data_dir,
+            record_length=5_000_000,
+            fs=500_000,
+        )
+    )
+
+    try:
+        hit_classification = st.get_array("timeS429", "hit_classification")
+
+        # Basic validation of the output
+        assert hit_classification is not None
+        assert len(hit_classification) >= 0  # Can be empty if no hits found
+
+        # Check that all required fields are present
+        required_fields = [
+            "time",
+            "endtime",
+            "channel",
+            "is_cr",
+            "is_symmetric_spike",
+            "is_unidentified",
+            "ma_rise_edge_slope",
+        ]
+        for field in required_fields:
+            assert (
+                field in hit_classification.dtype.names
+            ), f"Required field '{field}' missing from hit_classification"
+
+        # Check data types
+        assert hit_classification["time"].dtype == np.int64
+        assert hit_classification["endtime"].dtype == np.int64
+        assert hit_classification["channel"].dtype == np.int16
+        assert hit_classification["is_cr"].dtype == bool
+        assert hit_classification["is_symmetric_spike"].dtype == bool
+        assert hit_classification["is_unidentified"].dtype == bool
+        assert hit_classification["ma_rise_edge_slope"].dtype == np.float32
+
+        # Check that channels are within expected range (0-9 based on context config)
+        if len(hit_classification) > 0:
+            assert all(0 <= hit_classification["channel"]) and all(
+                hit_classification["channel"] <= 9
+            )
+
+        # Check that timing information is consistent
+        for hc_i, hit_class in enumerate(hit_classification):
+            expected_endtime = hit_class["time"] + (
+                hit_class["endtime"] - hit_class["time"]
+            )  # This should match
+            assert hit_class["endtime"] == expected_endtime, (
+                f"Hit classification #{hc_i} endtime mismatch. "
+                f"Note that hit_class['endtime'] is {hit_class['endtime']} and "
+                f"hit_class['time'] is {hit_class['time']}"
+            )
+
+        # Print classification statistics
+        if len(hit_classification) > 0:
+            n_cr = np.sum(hit_classification["is_cr"])
+            n_symmetric_spike = np.sum(hit_classification["is_symmetric_spike"])
+            n_unidentified = np.sum(hit_classification["is_unidentified"])
+
+            print(
+                f"Successfully processed {len(hit_classification)} hit classifications: "
+                f"{n_cr} cosmic rays, {n_symmetric_spike} symmetric spikes, "
+                f"{n_unidentified} unidentified"
+            )
+
+            assert n_cr == 60, "Expected 60 cosmic rays, got {}".format(n_cr)
+            assert n_unidentified == 0, "Expected 0 unidentified hits, got {}".format(
+                n_unidentified
+            )
+
+    except Exception as e:
+        pytest.fail(f"Failed to process hit classification: {str(e)}")

--- a/tests/test_hits.py
+++ b/tests/test_hits.py
@@ -226,7 +226,7 @@ def test_hits_processing():
         assert hits["amplitude_ma_min_ext"].dtype == np.float32
 
         # Check that all hits have the expected dt
-        expected_dt = int(1 / 500_000 * 1_000_000_000)  # Convert to nanoseconds
+        expected_dt = int(1 / 50_000 * 1_000_000_000)  # Convert to nanoseconds
         assert all(hits["dt"] == expected_dt)
 
         # Check that channels are within expected range (0-9 based on context config)

--- a/tests/test_hits.py
+++ b/tests/test_hits.py
@@ -165,12 +165,13 @@ def test_hits_processing():
 
     # Create context and process hits
     st = straxion.qualiphide()
-    st.set_config(
-        dict(
-            daq_input_dir=test_data_dir,
-            iq_finescan_dir=finescan_data_dir,
-        )
-    )
+    config = {
+        "daq_input_dir": test_data_dir,
+        "iq_finescan_dir": finescan_data_dir,
+        "record_length": 5_000_000,
+        "fs": 50_000,
+    }
+    st.set_config(config)
 
     try:
         hits = st.get_array("timeS429", "hits")
@@ -226,7 +227,7 @@ def test_hits_processing():
         assert hits["amplitude_ma_min_ext"].dtype == np.float32
 
         # Check that all hits have the expected dt
-        expected_dt = int(1 / 50_000 * 1_000_000_000)  # Convert to nanoseconds
+        expected_dt = int(1 / config["fs"] * 1_000_000_000)  # Convert to nanoseconds
         assert all(hits["dt"] == expected_dt)
 
         # Check that channels are within expected range (0-9 based on context config)

--- a/tests/test_hits.py
+++ b/tests/test_hits.py
@@ -30,10 +30,14 @@ def test_hits_dtype_inference():
         "data_theta_convolved",
         "hit_threshold",
         "aligned_at_records_i",
-        "amplitude_max",
-        "amplitude_min",
-        "amplitude_max_ext",
-        "amplitude_min_ext",
+        "amplitude_convolved_max",
+        "amplitude_convolved_min",
+        "amplitude_convolved_max_ext",
+        "amplitude_convolved_min_ext",
+        "amplitude_ma_max",
+        "amplitude_ma_min",
+        "amplitude_ma_max_ext",
+        "amplitude_ma_min_ext",
     ]
     field_names = [name[1] for name, *_ in dtype]
     for field in expected_fields:
@@ -190,10 +194,14 @@ def test_hits_processing():
             "data_theta_convolved",
             "hit_threshold",
             "aligned_at_records_i",
-            "amplitude_max",
-            "amplitude_min",
-            "amplitude_max_ext",
-            "amplitude_min_ext",
+            "amplitude_convolved_max",
+            "amplitude_convolved_min",
+            "amplitude_convolved_max_ext",
+            "amplitude_convolved_min_ext",
+            "amplitude_ma_max",
+            "amplitude_ma_min",
+            "amplitude_ma_max_ext",
+            "amplitude_ma_min_ext",
         ]
         for field in required_fields:
             assert field in hits.dtype.names, f"Required field '{field}' missing from hits"
@@ -210,10 +218,14 @@ def test_hits_processing():
         assert hits["data_theta_convolved"].dtype == np.float32
         assert hits["hit_threshold"].dtype == np.float32
         assert hits["aligned_at_records_i"].dtype == np.int32
-        assert hits["amplitude_max"].dtype == np.float32
-        assert hits["amplitude_min"].dtype == np.float32
-        assert hits["amplitude_max_ext"].dtype == np.float32
-        assert hits["amplitude_min_ext"].dtype == np.float32
+        assert hits["amplitude_convolved_max"].dtype == np.float32
+        assert hits["amplitude_convolved_min"].dtype == np.float32
+        assert hits["amplitude_convolved_max_ext"].dtype == np.float32
+        assert hits["amplitude_convolved_min_ext"].dtype == np.float32
+        assert hits["amplitude_ma_max"].dtype == np.float32
+        assert hits["amplitude_ma_min"].dtype == np.float32
+        assert hits["amplitude_ma_max_ext"].dtype == np.float32
+        assert hits["amplitude_ma_min_ext"].dtype == np.float32
 
         # Check that all hits have the expected dt
         expected_dt = int(1 / 500_000 * 1_000_000_000)  # Convert to nanoseconds
@@ -243,8 +255,10 @@ def test_hits_processing():
 
         # Check that hit characteristics are reasonable
         for hit in hits:
-            assert hit["amplitude_max"] >= hit["amplitude_min"]
-            assert hit["amplitude_max_ext"] >= hit["amplitude_min_ext"]
+            assert hit["amplitude_convolved_max"] >= hit["amplitude_convolved_min"]
+            assert hit["amplitude_convolved_max_ext"] >= hit["amplitude_convolved_min_ext"]
+            assert hit["amplitude_ma_max"] >= hit["amplitude_ma_min"]
+            assert hit["amplitude_ma_max_ext"] >= hit["amplitude_ma_min_ext"]
             assert hit["width"] > 0
             assert hit["hit_threshold"] > 0
 

--- a/tests/test_hits.py
+++ b/tests/test_hits.py
@@ -169,8 +169,6 @@ def test_hits_processing():
         dict(
             daq_input_dir=test_data_dir,
             iq_finescan_dir=finescan_data_dir,
-            record_length=5_000_000,
-            fs=500_000,
         )
     )
 

--- a/tests/test_raw_records.py
+++ b/tests/test_raw_records.py
@@ -41,7 +41,7 @@ def test_daq_reader_plugin_registration():
 def test_daq_reader_dtype_inference():
     """Test that DAQReader can infer the correct data type."""
     st = straxion.qualiphide()
-    config = {"daq_input_dir": "abracadabra", "record_length": 5_000_000, "fs": 500_000}
+    config = {"daq_input_dir": "abracadabra", "record_length": 5_000_000, "fs": 50_000}
     st.set_config(config)
     plugin = st.get_single_plugin("timeS429", "raw_records")
 
@@ -88,7 +88,7 @@ def test_raw_records_processing():
     # Create context and process raw_records
     st = straxion.qualiphide()
 
-    config = {"daq_input_dir": timeS429_dir, "record_length": 5_000_000, "fs": 500_000}
+    config = {"daq_input_dir": timeS429_dir, "record_length": 5_000_000, "fs": 50_000}
 
     clean_strax_data()
     try:
@@ -171,7 +171,7 @@ def test_raw_records_data_consistency():
     if not os.path.exists(timeS429_dir):
         pytest.fail(f"Test data directory {timeS429_dir} does not exist")
     st = straxion.qualiphide()
-    config = {"daq_input_dir": timeS429_dir, "record_length": 5_000_000, "fs": 500_000}
+    config = {"daq_input_dir": timeS429_dir, "record_length": 5_000_000, "fs": 50_000}
 
     clean_strax_data()
     try:
@@ -187,7 +187,7 @@ def test_daq_reader_missing_data_directory():
     """Test that DAQReader raises appropriate errors when data directory is missing."""
     st = straxion.qualiphide()
 
-    config = {"daq_input_dir": "/nonexistent/path", "record_length": 5_000_000, "fs": 500_000}
+    config = {"daq_input_dir": "/nonexistent/path", "record_length": 5_000_000, "fs": 50_000}
 
     clean_strax_data()
     with pytest.raises((ValueError, FileNotFoundError)):
@@ -202,7 +202,7 @@ def test_daq_reader_invalid_config():
     config = {
         "daq_input_dir": "/nonexistent/path",  # Use a non-existent path
         "record_length": -1,  # Invalid negative value
-        "fs": 500_000,
+        "fs": 50_000,
     }
 
     clean_strax_data()

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -430,6 +430,7 @@ class TestLoadFinescanFilesWithRealData:
         config = {
             "daq_input_dir": "timeS429",
             "iq_finescan_dir": test_data_dir,
+            "record_length": 5_000_000,
         }
 
         try:

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -429,8 +429,6 @@ class TestLoadFinescanFilesWithRealData:
 
         config = {
             "daq_input_dir": "timeS429",
-            "record_length": 5_000_000,
-            "fs": 500_000,
             "iq_finescan_dir": test_data_dir,
         }
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -431,6 +431,7 @@ class TestLoadFinescanFilesWithRealData:
             "daq_input_dir": "timeS429",
             "iq_finescan_dir": test_data_dir,
             "record_length": 5_000_000,
+            "fs": 50_000,
         }
 
         try:


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Implementation of hit classification against cosmic rays and symmetric spikes.

## Can you briefly describe how it works?
Algorithms kept the same from [Chris Albert's matlab code](https://github.com/FaroutYLq/axioph/tree/main/QUALIPHIDE/old_matlab).

## Can you give a minimal working example (or illustrate with a figure)?
```
hits = st.get_array("timeS429", ["hits", "hit_classification"])
```

And we got 6 `is_cr`, which is consistent with the `Matlab` result. However, I cannot reproduce the total number of interested hits passing all selections #22 . 

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
