### PR TITLE
Baseline monitor

### DIFF
--- a/notebooks/tutorial0_from_raw_to_hits.ipynb
+++ b/notebooks/tutorial0_from_raw_to_hits.ipynb
@@ -880,7 +880,7 @@
     "    bins=np.linspace(0, 1.2, 40),\n",
     "    label=\"Symmetric Spikes\",\n",
     ")\n",
-    "plt.xlabel(\"Convolved Amplitude (Extended) [20us]\")\n",
+    "plt.xlabel(\"Convolved Amplitude (Extended) [rad]\")\n",
     "plt.ylabel(\"Counts\")\n",
     "plt.legend(loc=\"best\")\n",
     "plt.yscale(\"log\")\n",

--- a/notebooks/tutorial0_from_raw_to_hits.ipynb
+++ b/notebooks/tutorial0_from_raw_to_hits.ipynb
@@ -592,6 +592,58 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d27fe565",
+   "metadata": {},
+   "source": [
+    "## `baseline_monitor`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40943e66",
+   "metadata": {},
+   "source": [
+    "The baseline monitor computes the standard deviation of the phase data in each 1 second interval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c7d4691",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.arange(10)[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32612cb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "baseline_monitor = st.get_array(\"timeS429\", \"baseline_monitor\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38ef480f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(baseline_monitor[\"baseline_monitor_std\"][0])\n",
+    "plt.plot(baseline_monitor[\"baseline_monitor_std_moving_average\"][0])\n",
+    "plt.plot(baseline_monitor[\"baseline_monitor_std_convolved\"][0])\n",
+    "plt.xlabel(\"Interval [1 second]\")\n",
+    "plt.ylabel(\"Baseline Std [rad]\")\n",
+    "plt.legend([\"Raw\", \"Moving Average\", \"Convolved\"], ncol=3, loc=\"best\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "eb4935b6",
    "metadata": {},
    "source": [

--- a/straxion/plugins/__init__.py
+++ b/straxion/plugins/__init__.py
@@ -9,3 +9,6 @@ from .hits import *
 
 from . import hit_classification
 from .hit_classification import *
+
+from . import baseline_monitor
+from .baseline_monitor import *

--- a/straxion/plugins/baseline_monitor.py
+++ b/straxion/plugins/baseline_monitor.py
@@ -47,6 +47,7 @@ class BaselineMonitor(strax.Plugin):
     def setup(self):
         total_length_ns = self.config["record_length"] / self.config["fs"] * SECOND_TO_NANOSECOND
         self.baseline_monitor_interval = total_length_ns // N_BASELINE_MONITOR_INTERVAL
+        # Window size for computing std.
         self.chunk_size = int(
             self.baseline_monitor_interval / SECOND_TO_NANOSECOND * self.config["fs"]
         )

--- a/straxion/plugins/baseline_monitor.py
+++ b/straxion/plugins/baseline_monitor.py
@@ -1,0 +1,118 @@
+import strax
+import numpy as np
+from straxion.utils import (
+    DATA_DTYPE,
+    TIME_DTYPE,
+    SECOND_TO_NANOSECOND,
+    base_waveform_dtype,
+    N_BASELINE_MONITOR_INTERVAL,
+)
+
+export, __all__ = strax.exporter()
+
+
+@export
+@strax.takes_config(
+    strax.Option(
+        "record_length",
+        default=5_000_000,
+        track=False,  # Not tracking record length, but we will have to check if it is as promised
+        type=int,
+        help=(
+            "Number of samples in each dataset."
+            "We assumed that each sample is equally spaced in time, with interval 1/fs."
+            "It should not go beyond a billion so that numpy can still handle."
+        ),
+    ),
+    strax.Option(
+        "fs",
+        default=50_000,
+        track=True,
+        type=int,
+        help="Sampling frequency (assumed the same for all channels) in unit of Hz",
+    ),
+)
+class BaselineMonitor(strax.Plugin):
+    """Monitor the baseline std of the phase data."""
+
+    __version__ = "0.0.0"
+    rechunk_on_save = False
+    compressor = "zstd"
+
+    depends_on = "records"
+    provides = "baseline_monitor"
+    data_kind = "records"
+    save_when = strax.SaveWhen.ALWAYS
+
+    def setup(self):
+        total_length_ns = self.config["record_length"] / self.config["fs"] * SECOND_TO_NANOSECOND
+        self.baseline_monitor_interval = total_length_ns // N_BASELINE_MONITOR_INTERVAL
+        self.chunk_size = int(
+            self.baseline_monitor_interval / SECOND_TO_NANOSECOND * self.config["fs"]
+        )
+
+    def infer_dtype(self):
+        dtype = base_waveform_dtype()
+        dtype.append(
+            (
+                (
+                    "Baseline monitoring interval in unit of nanoseconds.",
+                    "baseline_monitor_interval",
+                ),
+                TIME_DTYPE,
+            ),
+        )
+        dtype.append(
+            (
+                ("Baseline standard deviation of the raw data.", "baseline_monitor_std"),
+                DATA_DTYPE,
+                N_BASELINE_MONITOR_INTERVAL,
+            ),
+        )
+        dtype.append(
+            (
+                (
+                    "Baseline standard deviation of the smoothed data.",
+                    "baseline_monitor_std_moving_average",
+                ),
+                DATA_DTYPE,
+                N_BASELINE_MONITOR_INTERVAL,
+            ),
+        )
+        dtype.append(
+            (
+                (
+                    "Baseline standard deviation of the pulse kernel convolved data.",
+                    "baseline_monitor_std_convolved",
+                ),
+                DATA_DTYPE,
+                N_BASELINE_MONITOR_INTERVAL,
+            ),
+        )
+
+        return dtype
+
+    def compute(self, records):
+        # Copy common fields from records.
+        results = np.zeros(len(records), dtype=self.infer_dtype())
+        for field in ["time", "endtime", "length", "dt", "channel"]:
+            results[field] = records[field]
+
+        # Assign baseline monitor interval.
+        results["baseline_monitor_interval"] = self.baseline_monitor_interval
+
+        # Compute baseline std for every chunk.
+        for i in range(self.chunk_size):
+            results["baseline_monitor_std"][i] = np.std(
+                records["data_theta"][i * self.chunk_size : (i + 1) * self.chunk_size]
+            )
+            results["baseline_monitor_std_moving_average"][i] = np.std(
+                records["data_theta_moving_average"][
+                    i * self.chunk_size : (i + 1) * self.chunk_size
+                ]
+            )
+            results["baseline_monitor_std_convolved"][i] = np.std(
+                records["data_theta_convolved"][i * self.chunk_size : (i + 1) * self.chunk_size]
+            )
+
+        return results

--- a/straxion/plugins/raw_records.py
+++ b/straxion/plugins/raw_records.py
@@ -134,8 +134,6 @@ class DAQReader(strax.Plugin):
             np.ndarray: Structured array with fields 'time', 'I', and 'Q'.
 
         """
-
-
         def _read_header(f):
             header = np.fromfile(f, dtype=">d", count=2)
             n_coeffs = int(header[0])

--- a/straxion/plugins/raw_records.py
+++ b/straxion/plugins/raw_records.py
@@ -134,6 +134,8 @@ class DAQReader(strax.Plugin):
             np.ndarray: Structured array with fields 'time', 'I', and 'Q'.
 
         """
+
+
         def _read_header(f):
             header = np.fromfile(f, dtype=">d", count=2)
             n_coeffs = int(header[0])

--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -10,6 +10,9 @@ CHANNEL_DTYPE = np.int16
 DATA_DTYPE = np.dtype("f4")
 INDEX_DTYPE = np.int32
 
+# Baseline monitor interval.
+N_BASELINE_MONITOR_INTERVAL = 100
+
 # Hit waveform recording window length.
 HIT_WINDOW_LENGTH_LEFT = 300
 HIT_WINDOW_LENGTH_RIGHT = 300

--- a/tests/test_baseline_monitor.py
+++ b/tests/test_baseline_monitor.py
@@ -4,6 +4,13 @@ import os
 import straxion
 
 
+@pytest.mark.skipif(
+    not os.getenv("STRAXION_FINESCAN_DATA_DIR"),
+    reason=(
+        "Finescan test data directory not provided via "
+        "STRAXION_FINESCAN_DATA_DIR environment variable"
+    ),
+)
 class TestBaselineMonitor:
     """Test the BaselineMonitor plugin."""
 

--- a/tests/test_baseline_monitor.py
+++ b/tests/test_baseline_monitor.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+import os
+import straxion
+
+
+class TestBaselineMonitor:
+    """Test the BaselineMonitor plugin."""
+
+    def test_baseline_monitor_processing(self):
+        """Test the complete baseline monitor processing pipeline with real data.
+
+        This test requires the STRAXION_FINESCAN_DATA_DIR environment variable to be set to the path
+        containing the finescan test data directory.
+
+        """
+        test_data_dir = os.getenv("STRAXION_FINESCAN_DATA_DIR")
+        if not test_data_dir:
+            pytest.fail("STRAXION_FINESCAN_DATA_DIR environment variable is not set")
+        if not os.path.exists(test_data_dir):
+            pytest.fail(f"Finescan test data directory {test_data_dir} does not exist")
+
+        # Create context and process baseline monitor data
+        st = straxion.qualiphide()
+
+        config = {
+            "daq_input_dir": "timeS429",
+            "iq_finescan_dir": test_data_dir,
+            "record_length": 5_000_000,
+            "fs": 50_000,
+        }
+
+        try:
+            # Get baseline monitor data
+            bm = st.get_array("timeS429", "baseline_monitor", config=config)
+
+            # Basic validation of the output
+            assert bm is not None
+            assert len(bm) > 0
+
+            # Check that all required fields are present
+            required_fields = [
+                "time",
+                "endtime",
+                "length",
+                "dt",
+                "channel",
+                "baseline_monitor_interval",
+                "baseline_monitor_std",
+                "baseline_monitor_std_moving_average",
+                "baseline_monitor_std_convolved",
+            ]
+            for field in required_fields:
+                assert (
+                    field in bm.dtype.names
+                ), f"Required field '{field}' missing from baseline monitor"
+
+            # Check data types
+            assert bm["time"].dtype == np.int64
+            assert bm["endtime"].dtype == np.int64
+            assert bm["length"].dtype == np.int64
+            assert bm["dt"].dtype == np.int64
+            assert bm["channel"].dtype == np.int16
+            assert bm["baseline_monitor_interval"].dtype == np.int64
+            assert bm["baseline_monitor_std"].dtype == np.float32
+            assert bm["baseline_monitor_std_moving_average"].dtype == np.float32
+            assert bm["baseline_monitor_std_convolved"].dtype == np.float32
+
+            # Check that all records have the expected length
+            expected_length = config["record_length"]
+            assert all(bm["length"] == expected_length)
+
+            # Check that all records have the expected dt
+            expected_dt = int(1 / config["fs"] * 1_000_000_000)  # Convert to nanoseconds
+            assert all(bm["dt"] == expected_dt)
+
+            # Check that channels are within expected range (0-9 based on context config)
+            assert all(0 <= bm["channel"]) and all(bm["channel"] <= 9)
+
+            # Check that baseline monitor arrays have the correct shape
+            # Should have 100 intervals based on N_BASELINE_MONITOR_INTERVAL
+            expected_intervals = 100
+            for record in bm:
+                assert record["baseline_monitor_std"].shape == (expected_intervals,)
+                assert record["baseline_monitor_std_moving_average"].shape == (expected_intervals,)
+                assert record["baseline_monitor_std_convolved"].shape == (expected_intervals,)
+
+            # Check that baseline monitor interval is consistent across all records
+            expected_interval = (
+                expected_length // expected_intervals // config["fs"] * 1_000_000_000
+            )
+            assert all(bm["baseline_monitor_interval"] == expected_interval)
+
+            # Check that baseline std values are reasonable (should be positive)
+            assert np.all(bm["baseline_monitor_std"] >= 0)
+            assert np.all(bm["baseline_monitor_std_moving_average"] >= 0)
+            assert np.all(bm["baseline_monitor_std_convolved"] >= 0)
+
+            # Check that baseline std values are not all identical (should have some variation)
+            for channel in np.unique(bm["channel"]):
+                channel_data = bm[bm["channel"] == channel]
+                if len(channel_data) > 1:
+                    # Check that std values vary across intervals
+                    for record in channel_data:
+                        std_values = record["baseline_monitor_std"]
+                        std_ma_values = record["baseline_monitor_std_moving_average"]
+                        std_conv_values = record["baseline_monitor_std_convolved"]
+
+                        # Should not be all identical
+                        assert not np.allclose(
+                            std_values, std_values[0]
+                        ), f"Channel {channel} std values are constant"
+                        assert not np.allclose(
+                            std_ma_values, std_ma_values[0]
+                        ), f"Channel {channel} moving average std values are constant"
+                        assert not np.allclose(
+                            std_conv_values, std_conv_values[0]
+                        ), f"Channel {channel} convolved std values are constant"
+
+            print(
+                f"Successfully processed {len(bm)} baseline monitor records "
+                f"from {len(np.unique(bm['channel']))} channels"
+            )
+
+        except Exception as e:
+            pytest.fail(f"Failed to process baseline monitor data: {str(e)}")


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Implemented baseline monitor, which compute the std of baseline every 1 second (interval is controled by `utils.N_BASELINE_MONITOR_INTERVAL`).

## Can you briefly describe how it works?
Should have been explained above. Logically, this is a `records`-level plugin.

## Can you give a minimal working example (or illustrate with a figure)?
<img width="698" height="567" alt="image" src="https://github.com/user-attachments/assets/65a7fb8c-3ba8-4da1-bcd4-ab7aed3f061a" />


_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
