### PR TITLE
Save heavy dtype only when explicitly requested

### DIFF
--- a/straxion/plugins/raw_records.py
+++ b/straxion/plugins/raw_records.py
@@ -71,6 +71,7 @@ class QUALIPHIDETHzReader(strax.Plugin):
     provides: str = "raw_records"
     data_kind = provides
     depends_on: Tuple = tuple()  # This is the lowest level of strax data in processing.
+    save_when = strax.SaveWhen.EXPLICIT
 
     # Memory management related:
     rechunk_on_load = False  # Assumed no single dataset will be larger than 1 GB.

--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -94,7 +94,7 @@ class DxRecords(strax.Plugin):
     depends_on = "raw_records"
     provides = "records"
     data_kind = "records"
-    save_when = strax.SaveWhen.ALWAYS
+    save_when = strax.SaveWhen.EXPLICIT
 
     def infer_dtype(self):
         """Data type for a waveform record."""
@@ -461,7 +461,7 @@ class PulseProcessing(strax.Plugin):
     depends_on = "raw_records"
     provides = "records"
     data_kind = "records"
-    save_when = strax.SaveWhen.ALWAYS
+    save_when = strax.SaveWhen.EXPLICIT
 
     def infer_dtype(self):
         """Data type for a waveform record."""


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Save heavy dtype only when explicitly requested

## Can you briefly describe how it works?
Just forced strax savewhen

## Can you give a minimal working example (or illustrate with a figure)?
Should be automatically done in next make or get_array.

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
