### PR TITLE
Noise window gap and fixed noise window logic

### DIFF
--- a/straxion/plugins/noise_bank.py
+++ b/straxion/plugins/noise_bank.py
@@ -31,7 +31,7 @@ export, __all__ = strax.exporter()
 class NoiseBank(strax.Plugin):
     """Use the waveform noise_window_gap before the hit window to estimate the noise condition."""
 
-    __version__ = "0.0.0"
+    __version__ = "0.0.1"
     # Inherited from straxen. Not optimized outside XENONnT.
     rechunk_on_save = False
     compressor = "zstd"
@@ -125,6 +125,7 @@ class NoiseBank(strax.Plugin):
         self.fs = self.config["fs"]
         self.dt_exact = 1 / self.fs * SECOND_TO_NANOSECOND
         self.gap = self.config["noise_window_gap"]
+        assert self.gap >= 0, "noise_window_gap must be non-negative."
 
     def compute(self, records, hits):
         """Extract noise windows before each hit for noise characterization."""

--- a/straxion/plugins/noise_bank.py
+++ b/straxion/plugins/noise_bank.py
@@ -204,11 +204,17 @@ class NoiseBank(strax.Plugin):
 
             # Check for overlaps with previous hits
             if len(hits_ch) > 1:
+                previous_hit_starts = np.full(len(hits_ch), -1)
+                previous_hit_starts[1:] = (
+                    hits_ch["amplitude_convolved_max_record_i"][:-1] - HIT_WINDOW_LENGTH_LEFT
+                )
                 prev_hit_ends = np.full(len(hits_ch), -1)
                 prev_hit_ends[1:] = (
                     hits_ch["amplitude_convolved_max_record_i"][:-1] + HIT_WINDOW_LENGTH_RIGHT
                 )
-                overlap_mask = prev_hit_ends < start_indices
+                overlap_mask = ~(
+                    (prev_hit_ends > start_indices) & (previous_hit_starts < end_indices)
+                )
                 valid_mask &= overlap_mask
 
             # Process valid hits

--- a/straxion/plugins/noise_bank.py
+++ b/straxion/plugins/noise_bank.py
@@ -124,6 +124,7 @@ class NoiseBank(strax.Plugin):
         self.noise_window_length = HIT_WINDOW_LENGTH_LEFT + HIT_WINDOW_LENGTH_RIGHT
         self.fs = self.config["fs"]
         self.dt_exact = 1 / self.fs * SECOND_TO_NANOSECOND
+        self.gap = self.config["noise_window_gap"]
 
     def compute(self, records, hits):
         """Extract noise windows before each hit for noise characterization."""
@@ -191,8 +192,11 @@ class NoiseBank(strax.Plugin):
                 hits_ch["amplitude_convolved_max_record_i"]
                 - HIT_WINDOW_LENGTH_LEFT
                 - self.noise_window_length
+                - self.gap
             )
-            end_indices = hits_ch["amplitude_convolved_max_record_i"] - HIT_WINDOW_LENGTH_LEFT
+            end_indices = (
+                hits_ch["amplitude_convolved_max_record_i"] - HIT_WINDOW_LENGTH_LEFT - self.gap
+            )
 
             # Filter valid hits (start_i >= 0)
             valid_mask = start_indices >= 0


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
- Previously, `noise_window_gap` is defined but unused in config. Now it is in use.
- Corrects the logic for detecting overlapping hits in the NoiseBank plugin by updating the calculation of previous hit start indices and the overlap mask. This ensures valid hits are properly identified when checking for overlaps.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
