### PR TITLE
Apply mean correction to kernel-convolved dx data

### DIFF
--- a/straxion/plugins/records.py
+++ b/straxion/plugins/records.py
@@ -318,6 +318,7 @@ class DxRecords(strax.Plugin):
         4. Calculates IQ loop centers using circle fitting
         5. Computes phi values for each channel
         6. Corrects the fine scan data by rotating back the centered IQ by the phi values.
+        7. Corrects the fine scan data by the mean of the kernel-convolved dx.
         """
         # Load fine and wide scan files, as well as resonant frequency file.
         self._load_correction_files()
@@ -529,6 +530,12 @@ class DxRecords(strax.Plugin):
             else:
                 _convolved = np.convolve(r["data_dx"], self.kernel, mode="full")
             r["data_dx_convolved"] = _convolved[-self.record_length :]
+
+            # Correct all dx by the mean of the kernel-convolved dx.
+            dx_convolved_mean = np.mean(r["data_dx_convolved"])
+            r["data_dx"] = r["data_dx"] - dx_convolved_mean
+            r["data_dx_moving_average"] = r["data_dx_moving_average"] - dx_convolved_mean
+            r["data_dx_convolved"] = r["data_dx_convolved"] - dx_convolved_mean
 
         return results
 


### PR DESCRIPTION
Adds a step to correct all dx-related arrays by subtracting the mean of the kernel-convolved dx. This ensures that the fine scan data is centered after convolution, improving data consistency.

_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

So far, we assume a perfect match between fine scan and timestreams, which is not the case due to many mechanisms, including drifting. This results into a small discrepancy between the baseline of dx and 0, which should further lead to a little bias in energy estimation.

<img width="669" height="508" alt="image" src="https://github.com/user-attachments/assets/1775c07b-4e8a-4e2d-a5d6-0de24f7d4cae" />

As a quick fix, we can just shift the whole dx by its mean. Note that this is not a perfect fix from first principles.

## Can you briefly describe how it works?

```python
            # Correct all dx by the mean of the kernel-convolved dx.
            dx_convolved_mean = np.mean(r["data_dx_convolved"])
            r["data_dx"] = r["data_dx"] - dx_convolved_mean
            r["data_dx_moving_average"] = r["data_dx_moving_average"] - dx_convolved_mean
            r["data_dx_convolved"] = r["data_dx_convolved"] - dx_convolved_mean
```

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
