### PR TITLE
Debug noise window gap times

### DIFF
--- a/straxion/plugins/noise_bank.py
+++ b/straxion/plugins/noise_bank.py
@@ -142,8 +142,10 @@ class NoiseBank(strax.Plugin):
         results = np.zeros(len(valid_hits), dtype=self.infer_dtype())
 
         # Vectorized assignments
-        results["time"] = valid_hits["time"] - np.int64(self.noise_window_length * self.dt_exact)
-        results["endtime"] = valid_hits["time"]
+        results["time"] = valid_hits["time"] - np.int64(
+            (self.noise_window_length + self.gap) * self.dt_exact
+        )
+        results["endtime"] = valid_hits["time"] - np.int64(self.gap * self.dt_exact)
         results["data_dx"] = noise_data["data_dx"]
         results["data_dx_moving_average"] = noise_data["data_dx_moving_average"]
         results["data_dx_convolved"] = noise_data["data_dx_convolved"]

--- a/straxion/plugins/noise_bank.py
+++ b/straxion/plugins/noise_bank.py
@@ -31,7 +31,7 @@ export, __all__ = strax.exporter()
 class NoiseBank(strax.Plugin):
     """Use the waveform noise_window_gap before the hit window to estimate the noise condition."""
 
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"
     # Inherited from straxen. Not optimized outside XENONnT.
     rechunk_on_save = False
     compressor = "zstd"


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
A bug was introduced in #48: the `time` and `endtime` of `noises` are not updated properly. They still assumed `0` for `noise_window_gap`.

## Can you briefly describe how it works?
Just make sure the `time` and `endtime` have been shifted correspondingly. 

## Can you give a minimal working example (or illustrate with a figure)?
```python
%matplotlib widget

times_start = record["time"]
times_us = (record["time"] + np.arange(record["length"]) * record["dt"] - times_start) / 1e3

plt.figure(figsize=(6, 3))
plt.plot(
    times_us,
    record["data_dx"],
    label="Raw",
    # color="black",
    alpha=0.5,
    lw=1,
)
plt.plot(
    times_us,
    record["data_dx_moving_average"],
    label="Moving Averaged",
    # color="tab:blue",
    lw=1,
)
plt.plot(
    times_us,
    record["data_dx_convolved"],
    label="Convolved with Pulse Kernel",
    # color="tab:orange",
    lw=2,
)

for hit in hits0:
    hit_start_us = (hit["time"] - times_start) / 1e3
    hit_end_us = (hit["endtime"] - times_start) / 1e3
    plt.axvspan(hit_start_us, hit_end_us, alpha=0.2, color="xenon_red", lw=0)
    plt.axvspan(times_us[hit["amplitude_moving_average_max_record_i"]-5], times_us[hit["amplitude_moving_average_max_record_i"]], color="xenon_blue", alpha=0.2, lw=0)
    #plt.axvline(hit["amplitude_max_record_i"] * record["dt"] / 1e3, color="xenon_red")

for noise in noises0:
    noise_start_us = (noise["time"] - times_start) / 1e3
    noise_end_us = (noise["endtime"] - times_start) / 1e3
    plt.axvspan(noise_start_us, noise_end_us, alpha=0.2, color="xenon_green", lw=0)

plt.axhline(hit["hit_threshold"], color="xenon_light_blue", ls=":")

plt.xlabel("Time Since Run Start [us]")
plt.ylabel("dx")
plt.show()
```

<img width="1199" height="598" alt="image" src="https://github.com/user-attachments/assets/f256bf23-1c49-45e7-936a-e8c9d847656b" />

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
