### PR TITLE
Fixed windowing logic in OF

### DIFF
--- a/straxion/plugins/hit_classification.py
+++ b/straxion/plugins/hit_classification.py
@@ -367,8 +367,8 @@ class DxHitClassification(strax.Plugin):
                     "of_window_left and of_window_right must be "
                     "provided when apply_window is True"
                 )
-            window_start = HIT_WINDOW_LENGTH_LEFT - of_window_left
-            window_end = HIT_WINDOW_LENGTH_LEFT + of_window_right
+            window_start = max_index - of_window_left
+            window_end = max_index + of_window_right
             At_modified = At_modified[window_start:window_end]
 
         return At_modified
@@ -465,8 +465,10 @@ class DxHitClassification(strax.Plugin):
             Template shifted to best position and scaled by best_aOF
         """
         # Apply windowing to signal
-        window_start = HIT_WINDOW_LENGTH_LEFT - of_window_left
-        window_end = HIT_WINDOW_LENGTH_LEFT + of_window_right
+        t_seconds = np.arange(len(St)) * dt_seconds
+        max_index = np.argmin((t_seconds - t_max_seconds) ** 2)
+        window_start = max_index - of_window_left
+        window_end = max_index + of_window_right
         St_windowed = St[window_start:window_end]
 
         # Coarse scan for optimal time shift


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Previously, the OF will introduce artificial delay in tau. It turns out to be related to where the maximum amplitude index is defined. Here we make things self-consistent.

## Can you briefly describe how it works?

Instead of assuming `HIT_WINDOW_LENGTH_LEFT` to be the maximum height index, the maximum height index is computed in the fly

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._

All _italic_ comments can be removed from this template.
