### PR TITLE
Add customization options to plot_channels

### DIFF
--- a/straxion/colors.py
+++ b/straxion/colors.py
@@ -75,7 +75,7 @@ def plot_channels(
     ax=None,
     figsize=(4, 3),
     s=250,
-    cmap=None,
+    cmap="magma",
     vmin=None,
     vmax=None,
     xlim=(-1, 21),
@@ -85,6 +85,8 @@ def plot_channels(
     title=None,
     colorbar_label=None,
     colorbar_orientation="horizontal",
+    save_pdf_at=None,
+    highlight_central=True,
     **kwargs,
 ):
     """
@@ -110,7 +112,7 @@ def plot_channels(
     s : float, optional
         Size of scatter points. Default is 100.
     cmap : str or Colormap, optional
-        Colormap to use. Default is None (uses default).
+        Colormap to use. Default is 'magma'.
     vmin, vmax : float, optional
         Color scale limits.
     xlim, ylim : tuple, optional
@@ -124,6 +126,11 @@ def plot_channels(
     colorbar_orientation : str, optional
         Orientation of colorbar. 'horizontal' or 'vertical'.
         Default is 'horizontal'.
+    save_pdf_at : str or path-like, optional
+        If given, save the figure as a PDF at this path. Default is None.
+    highlight_central : bool, optional
+        If True, draw red circles around the central channels. Default
+        is True.
     **kwargs
         Additional arguments passed to scatter.
 
@@ -226,20 +233,21 @@ def plot_channels(
         **kwargs,
     )
 
-    # Add circles on central channels (always drawn)
-    from matplotlib.patches import Circle
+    # Add circles on central channels
+    if highlight_central:
+        from matplotlib.patches import Circle
 
-    central_positions = [freq_to_position_mapping[freq_idx] for freq_idx in central]
-    for pos_idx in central_positions:
-        circle = Circle(
-            (centers[0, pos_idx], centers[1, pos_idx]),
-            radius=0.4,
-            fill=False,
-            edgecolor="#B9123E",
-            linewidth=1,
-            zorder=10,
-        )
-        ax.add_patch(circle)
+        central_positions = [freq_to_position_mapping[freq_idx] for freq_idx in central]
+        for pos_idx in central_positions:
+            circle = Circle(
+                (centers[0, pos_idx], centers[1, pos_idx]),
+                radius=0.4,
+                fill=False,
+                edgecolor="#B9123E",
+                linewidth=1,
+                zorder=10,
+            )
+            ax.add_patch(circle)
 
     # Add colorbar
     if colorbar_label is None:
@@ -252,9 +260,12 @@ def plot_channels(
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     ax.set_aspect("equal")
-    ax.tick_params(length=1)
+    ax.tick_params(length=0)
 
     if title is not None:
         ax.set_title(title)
+
+    if save_pdf_at is not None:
+        fig.savefig(save_pdf_at, format="pdf", bbox_inches="tight")
 
     return fig, ax, sc

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,85 @@
+import os
+import tempfile
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import straxion  # noqa: E402
+
+
+def test_register_xenon_colors():
+    straxion.register_xenon_colors()
+    assert matplotlib.colors.to_hex("xenon_blue") == "#4067b1"
+    assert matplotlib.colors.to_hex("xenon_red") == "#b9123e"
+
+
+def test_plot_channels_basic():
+    values = np.arange(41, dtype=float)
+    fig, ax, sc = straxion.plot_channels(values)
+    assert fig is not None
+    assert ax is not None
+    assert sc.get_cmap().name == "magma"
+    plt.close(fig)
+
+
+def test_plot_channels_wrong_length_raises():
+    with pytest.raises(ValueError):
+        straxion.plot_channels(np.arange(10))
+
+
+def test_plot_channels_existing_axes():
+    values = np.arange(41, dtype=float)
+    fig, ax = plt.subplots()
+    out_fig, out_ax, _ = straxion.plot_channels(values, ax=ax)
+    assert out_ax is ax
+    assert out_fig is fig
+    plt.close(fig)
+
+
+def test_plot_channels_no_highlight_central():
+    values = np.arange(41, dtype=float)
+    fig_with, _, _ = straxion.plot_channels(values, highlight_central=True)
+    n_patches_with = len(fig_with.axes[0].patches)
+    plt.close(fig_with)
+
+    fig_without, _, _ = straxion.plot_channels(values, highlight_central=False)
+    n_patches_without = len(fig_without.axes[0].patches)
+    plt.close(fig_without)
+
+    assert n_patches_with - n_patches_without == 4
+
+
+def test_plot_channels_plot_center_false():
+    values = np.arange(41, dtype=float)
+    fig, _, _ = straxion.plot_channels(values, plot_center=False)
+    plt.close(fig)
+
+
+def test_plot_channels_save_pdf_at():
+    values = np.arange(41, dtype=float)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, "out.pdf")
+        fig, _, _ = straxion.plot_channels(values, save_pdf_at=out)
+        plt.close(fig)
+        assert os.path.exists(out)
+        assert os.path.getsize(out) > 0
+        with open(out, "rb") as f:
+            assert f.read(4) == b"%PDF"
+
+
+def test_plot_channels_vertical_colorbar_and_title():
+    values = np.arange(41, dtype=float)
+    fig, ax, _ = straxion.plot_channels(
+        values,
+        colorbar_orientation="vertical",
+        colorbar_label="test",
+        title="hello",
+        vmin=0,
+        vmax=40,
+    )
+    assert ax.get_title() == "hello"
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- Default `cmap` is now `"magma"`
- New `save_pdf_at` parameter to save the figure as a PDF
- New `highlight_central` parameter to optionally skip the red circles around central channels
- Remove tick stick marks (`length=0`)

## Test plan
- [ ] `plot_channels(values)` renders with the magma colormap and no tick sticks
- [ ] `plot_channels(values, highlight_central=False)` omits the red circles
- [ ] `plot_channels(values, save_pdf_at="out.pdf")` writes a valid PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)