### PR TITLE
Add get_channel_position to retrieve KID array (x, y) in mm

### DIFF
--- a/straxion/colors.py
+++ b/straxion/colors.py
@@ -1,5 +1,88 @@
 import numpy as np
 
+# QUALIPHIDE-FIR KID array layout.
+# Maps frequency channel index (0-40) to layout position index (0-43)
+# in the 2-row x 22-column array.
+_FREQ_TO_POSITION_MAPPING = {
+    0: 0,  # A1
+    1: 22,  # A2
+    2: 13,  # B1
+    3: 35,  # B2
+    4: 5,  # C1
+    5: 27,  # C2
+    6: 8,  # D1
+    7: 30,  # D2
+    8: 4,  # E1
+    9: 26,  # E2
+    10: 21,  # F1
+    11: 43,  # F2
+    12: 12,  # G1
+    13: 34,  # G2
+    14: 38,  # H2
+    15: 3,  # I1
+    16: 25,  # I2
+    17: 20,  # J1
+    18: 42,  # J2
+    19: 39,  # K2
+    20: 31,  # L2
+    21: 9,  # L1
+    22: 15,  # M1
+    23: 37,  # M2
+    24: 29,  # N2
+    25: 36,  # O2
+    26: 14,  # O1
+    27: 23,  # P2
+    28: 1,  # P1
+    29: 6,  # Q1
+    30: 28,  # Q2
+    31: 10,  # R1
+    32: 32,  # R2
+    33: 19,  # S1
+    34: 41,  # S2
+    35: 2,  # T1
+    36: 24,  # T2
+    37: 11,  # U1
+    38: 33,  # U2
+    39: 18,  # V1
+    40: 40,  # V2
+}
+
+
+def _build_channel_centers():
+    centers = np.zeros((2, 2, 22))  # x/y, row, col
+    centers[1, 0, :] = 0.779  # top row y (mm); bottom row y = 0
+    for i in range(22):
+        centers[0, 0, i] = i * 0.9 + 0.45  # top row x (mm)
+        centers[0, 1, i] = i * 0.9  # bottom row x (mm)
+    centers = centers.reshape(2, 44)
+    sorted_indices = np.argsort(centers[0, :])
+    return centers[:, sorted_indices]
+
+
+# Position-indexed (x, y) coordinates in mm, shape (2, 44).
+_CHANNEL_CENTERS_MM = _build_channel_centers()
+
+
+def get_channel_position(channel):
+    """Get the (x, y) position of a frequency channel in mm.
+
+    Layout is the QUALIPHIDE-FIR KID array (2 rows x 22 columns).
+
+    Parameters
+    ----------
+    channel : int
+        Frequency channel index (0-40).
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (2,) containing [x, y] position in mm.
+    """
+    if channel not in _FREQ_TO_POSITION_MAPPING:
+        raise ValueError(f"Channel index must be in 0-40, got {channel}")
+    pos_idx = _FREQ_TO_POSITION_MAPPING[channel]
+    return _CHANNEL_CENTERS_MM[:, pos_idx].copy()
+
 
 def register_xenon_colors():
     """Register Xenon color palette as named colors in matplotlib and set as default color cycle.
@@ -134,49 +217,7 @@ def plot_channels(
     """
     import matplotlib.pyplot as plt
 
-    freq_to_position_mapping = {
-        0: 0,  # A1
-        1: 22,  # A2
-        2: 13,  # B1
-        3: 35,  # B2
-        4: 5,  # C1
-        5: 27,  # C2
-        6: 8,  # D1
-        7: 30,  # D2
-        8: 4,  # E1
-        9: 26,  # E2
-        10: 21,  # F1
-        11: 43,  # F2
-        12: 12,  # G1
-        13: 34,  # G2
-        14: 38,  # H2
-        15: 3,  # I1
-        16: 25,  # I2
-        17: 20,  # J1
-        18: 42,  # J2
-        19: 39,  # K2
-        20: 31,  # L2
-        21: 9,  # L1
-        22: 15,  # M1
-        23: 37,  # M2
-        24: 29,  # N2
-        25: 36,  # O2
-        26: 14,  # O1
-        27: 23,  # P2
-        28: 1,  # P1
-        29: 6,  # Q1
-        30: 28,  # Q2
-        31: 10,  # R1
-        32: 32,  # R2
-        33: 19,  # S1
-        34: 41,  # S2
-        35: 2,  # T1
-        36: 24,  # T2
-        37: 11,  # U1
-        38: 33,  # U2
-        39: 18,  # V1
-        40: 40,  # V2
-    }
+    freq_to_position_mapping = _FREQ_TO_POSITION_MAPPING
 
     # Validate input
     values = np.array(values)
@@ -186,16 +227,7 @@ def plot_channels(
     # Create inverse mapping: position -> frequency
     position_to_freq_mapping = {pos: freq for freq, pos in freq_to_position_mapping.items()}
 
-    # Create channel centers
-    centers = np.zeros((2, 2, 22))  # x/y, row, col
-    centers[1, 0, :] = 0.779  # top row y, bottom y = 0
-    for i in range(22):
-        centers[0, 0, i] = i * 0.9 + 0.45  # top row x
-        centers[0, 1, i] = i * 0.9  # bottom row x
-
-    centers = centers.reshape(2, 44)
-    sorted_indices = np.argsort(centers[0, :])
-    centers = centers[:, sorted_indices]
+    centers = _CHANNEL_CENTERS_MM
 
     # Determine which channels to exclude
     missing_positions = list(missing)

--- a/straxion/colors.py
+++ b/straxion/colors.py
@@ -70,18 +70,27 @@ def get_channel_position(channel):
 
     Parameters
     ----------
-    channel : int
-        Frequency channel index (0-40).
+    channel : int or array-like of int
+        Frequency channel index (0-40), or an array of indices.
 
     Returns
     -------
     np.ndarray
-        Array of shape (2,) containing [x, y] position in mm.
+        For scalar input: shape (2,) array containing [x, y] in mm.
+        For array input of length N: shape (N, 2) array of [x, y] in mm.
     """
-    if channel not in _FREQ_TO_POSITION_MAPPING:
-        raise ValueError(f"Channel index must be in 0-40, got {channel}")
-    pos_idx = _FREQ_TO_POSITION_MAPPING[channel]
-    return _CHANNEL_CENTERS_MM[:, pos_idx].copy()
+    arr = np.asarray(channel)
+    if arr.ndim == 0:
+        ch = int(arr)
+        if ch not in _FREQ_TO_POSITION_MAPPING:
+            raise ValueError(f"Channel index must be in 0-40, got {ch}")
+        return _CHANNEL_CENTERS_MM[:, _FREQ_TO_POSITION_MAPPING[ch]].copy()
+
+    invalid = [int(c) for c in arr.ravel() if int(c) not in _FREQ_TO_POSITION_MAPPING]
+    if invalid:
+        raise ValueError(f"Channel indices must be in 0-40, got invalid values: {invalid}")
+    pos_indices = np.array([_FREQ_TO_POSITION_MAPPING[int(c)] for c in arr.ravel()])
+    return _CHANNEL_CENTERS_MM[:, pos_indices].T.reshape(*arr.shape, 2).copy()
 
 
 def register_xenon_colors():

--- a/tests/test_channel_position.py
+++ b/tests/test_channel_position.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+import straxion
+
+
+def test_returns_array_of_shape_2():
+    pos = straxion.get_channel_position(0)
+    assert isinstance(pos, np.ndarray)
+    assert pos.shape == (2,)
+
+
+def test_all_channels_return_valid_positions():
+    positions = np.array([straxion.get_channel_position(i) for i in range(41)])
+    assert positions.shape == (41, 2)
+    # y is either bottom row (0) or top row (0.779 mm).
+    assert set(np.unique(positions[:, 1])) == {0.0, 0.779}
+    # x spans the 22-column layout at 0.9 mm pitch.
+    assert positions[:, 0].min() == pytest.approx(0.0)
+    assert positions[:, 0].max() == pytest.approx(19.35)
+
+
+def test_all_positions_unique():
+    positions = [tuple(straxion.get_channel_position(i)) for i in range(41)]
+    assert len(set(positions)) == 41
+
+
+def test_invalid_channel_raises():
+    with pytest.raises(ValueError):
+        straxion.get_channel_position(41)
+    with pytest.raises(ValueError):
+        straxion.get_channel_position(-1)
+
+
+def test_returns_copy_not_view():
+    pos = straxion.get_channel_position(0)
+    pos[0] = 999.0
+    # A second call should not be affected by mutation of the first result.
+    assert straxion.get_channel_position(0)[0] == 0.0

--- a/tests/test_channel_position.py
+++ b/tests/test_channel_position.py
@@ -37,3 +37,29 @@ def test_returns_copy_not_view():
     pos[0] = 999.0
     # A second call should not be affected by mutation of the first result.
     assert straxion.get_channel_position(0)[0] == 0.0
+
+
+def test_array_input_returns_n_by_2():
+    channels = np.array(
+        [7, 16, 30, 32, 38, 10, 17, 19, 25, 27, 33, 34, 35, 39, 4, 11, 12, 22, 8, 28, 15],
+        dtype=np.int16,
+    )
+    out = straxion.get_channel_position(channels)
+    assert out.shape == (len(channels), 2)
+    # Each row matches the scalar result for that channel.
+    for i, ch in enumerate(channels):
+        assert np.array_equal(out[i], straxion.get_channel_position(int(ch)))
+
+
+def test_array_input_list_and_dtypes():
+    # Plain list input works.
+    out_list = straxion.get_channel_position([0, 5, 40])
+    assert out_list.shape == (3, 2)
+    # int16 (the realistic CHANNEL_DTYPE) works.
+    out_int16 = straxion.get_channel_position(np.array([0, 5, 40], dtype=np.int16))
+    assert np.array_equal(out_list, out_int16)
+
+
+def test_array_input_invalid_raises():
+    with pytest.raises(ValueError):
+        straxion.get_channel_position(np.array([0, 41]))


### PR DESCRIPTION
## Summary
- Adds `straxion.get_channel_position(channel)` returning `np.array([x, y])` in mm for the QUALIPHIDE-FIR KID array layout.
- Extracts the frequency-to-position mapping and channel centers from `plot_channels` into shared module-level constants (`_FREQ_TO_POSITION_MAPPING`, `_CHANNEL_CENTERS_MM`) so both functions use a single source of truth.
- Adds `tests/test_channel_position.py` covering shape, layout invariants (y in {0, 0.779}, x range 0–19.35 mm), uniqueness across all 41 channels, invalid input, and that returned arrays are copies.

## Test plan
- [x] `pytest tests/test_channel_position.py` (5 passed)
- [x] CI green on the rest of the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)