### PR TITLE
Add find_run_for_hit helper to map a hit time to its run_id

### DIFF
--- a/straxion/utils.py
+++ b/straxion/utils.py
@@ -1,3 +1,4 @@
+import bisect
 import numpy as np
 import pickle
 import os
@@ -79,6 +80,48 @@ def timestamp_to_nanoseconds(timestamp_str):
     nanoseconds = int(unix_timestamp * 1_000_000_000)
 
     return nanoseconds
+
+
+def find_run_for_hit(hit_time, run_ids, run_ends_ns=None):
+    """Return the run_id whose time window contains a hit.
+
+    Run IDs are assumed to be Unix-second timestamp strings (the straxion convention,
+    e.g. "1756824965"), and ``hit_time`` is in nanoseconds since the Unix epoch
+    (the strax ``time`` field convention).
+
+    Args:
+        hit_time (int): Hit timestamp in nanoseconds since the Unix epoch.
+        run_ids (sequence of str or int): Run identifiers. Each is interpreted as a
+            Unix-second start time. Need not be sorted.
+        run_ends_ns (sequence of int, optional): Explicit run end times in
+            nanoseconds since the Unix epoch, aligned with ``run_ids``. If provided,
+            a hit only matches a run when ``start <= hit_time < end``; otherwise
+            ``None`` is returned. If ``None``, each run is treated as ending at the
+            next run's start (and the last run as open-ended).
+
+    Returns:
+        str or None: The matching run_id (as a string, matching strax conventions),
+        or ``None`` if the hit does not fall inside any run.
+
+    """
+    if len(run_ids) == 0:
+        return None
+
+    starts_ns = np.array([int(rid) * 1_000_000_000 for rid in run_ids], dtype=np.int64)
+    order = np.argsort(starts_ns)
+    starts_sorted = starts_ns[order]
+    ids_sorted = [str(run_ids[i]) for i in order]
+
+    idx = bisect.bisect_right(starts_sorted.tolist(), int(hit_time)) - 1
+    if idx < 0:
+        return None
+
+    if run_ends_ns is not None:
+        end_ns = int(np.asarray(run_ends_ns)[order[idx]])
+        if int(hit_time) >= end_ns:
+            return None
+
+    return ids_sorted[idx]
 
 
 def circfit(x, y):

--- a/tests/test_find_run_for_hit.py
+++ b/tests/test_find_run_for_hit.py
@@ -1,0 +1,109 @@
+import pytest
+
+import straxion
+
+NS = 1_000_000_000
+
+
+def test_hit_at_run_start_returns_that_run():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    assert straxion.find_run_for_hit(1756824965 * NS, runs) == "1756824965"
+
+
+def test_hit_inside_run_returns_that_run():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    assert straxion.find_run_for_hit(1756824965 * NS + NS, runs) == "1756824965"
+    assert straxion.find_run_for_hit(1756830500 * NS, runs) == "1756830000"
+
+
+def test_hit_after_last_run_open_ended():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    # With no explicit ends, the last run is treated as open-ended.
+    assert straxion.find_run_for_hit(1757000000 * NS, runs) == "1756900000"
+
+
+def test_hit_before_first_run_returns_none():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    assert straxion.find_run_for_hit(1756000000 * NS, runs) is None
+
+
+def test_unsorted_input_handled():
+    runs = ["1756900000", "1756824965", "1756830000"]
+    assert straxion.find_run_for_hit(1756830500 * NS, runs) == "1756830000"
+    assert straxion.find_run_for_hit(1756824965 * NS, runs) == "1756824965"
+
+
+def test_explicit_run_ends_inside_window():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    ends = [(1756824965 + 100) * NS, (1756830000 + 100) * NS, (1756900000 + 100) * NS]
+    assert straxion.find_run_for_hit((1756824965 + 50) * NS, runs, ends) == "1756824965"
+
+
+def test_explicit_run_ends_inter_run_gap_returns_none():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    ends = [(1756824965 + 100) * NS, (1756830000 + 100) * NS, (1756900000 + 100) * NS]
+    # 500s after run0 start is past run0 end and before run1 start.
+    assert straxion.find_run_for_hit((1756824965 + 500) * NS, runs, ends) is None
+
+
+def test_explicit_run_ends_past_last_end_returns_none():
+    runs = ["1756824965", "1756830000", "1756900000"]
+    ends = [(1756824965 + 100) * NS, (1756830000 + 100) * NS, (1756900000 + 100) * NS]
+    assert straxion.find_run_for_hit((1756900000 + 200) * NS, runs, ends) is None
+
+
+def test_explicit_run_ends_unsorted_input():
+    runs = ["1756900000", "1756824965", "1756830000"]
+    ends = [(1756900000 + 100) * NS, (1756824965 + 100) * NS, (1756830000 + 100) * NS]
+    # Hit inside run1's window.
+    assert straxion.find_run_for_hit((1756830000 + 50) * NS, runs, ends) == "1756830000"
+    # Hit in the gap after run0.
+    assert straxion.find_run_for_hit((1756824965 + 500) * NS, runs, ends) is None
+
+
+def test_empty_run_list_returns_none():
+    assert straxion.find_run_for_hit(1756824965 * NS, []) is None
+
+
+def test_integer_run_ids_accepted():
+    runs = [1756824965, 1756830000, 1756900000]
+    assert straxion.find_run_for_hit(1756830500 * NS, runs) == "1756830000"
+
+
+def test_hit_exactly_at_run_end_excluded():
+    # End is exclusive: hit_time == end falls into the next run (or None if gap).
+    runs = ["1756824965", "1756830000"]
+    ends = [(1756824965 + 100) * NS, (1756830000 + 100) * NS]
+    # hit exactly at run0's end, before run1 -> None (in gap).
+    assert straxion.find_run_for_hit((1756824965 + 100) * NS, runs, ends) is None
+
+
+def test_single_run():
+    runs = ["1756824965"]
+    assert straxion.find_run_for_hit(1756824965 * NS, runs) == "1756824965"
+    assert straxion.find_run_for_hit(1756824965 * NS + NS, runs) == "1756824965"
+    assert straxion.find_run_for_hit(1756824964 * NS, runs) is None
+
+
+def test_single_run_with_end():
+    runs = ["1756824965"]
+    ends = [(1756824965 + 10) * NS]
+    assert straxion.find_run_for_hit((1756824965 + 5) * NS, runs, ends) == "1756824965"
+    assert straxion.find_run_for_hit((1756824965 + 20) * NS, runs, ends) is None
+
+
+@pytest.mark.parametrize(
+    "hit_seconds, expected",
+    [
+        (1756824964, None),
+        (1756824965, "1756824965"),
+        (1756829999, "1756824965"),
+        (1756830000, "1756830000"),
+        (1756899999, "1756830000"),
+        (1756900000, "1756900000"),
+        (1800000000, "1756900000"),
+    ],
+)
+def test_parametrized_boundaries(hit_seconds, expected):
+    runs = ["1756824965", "1756830000", "1756900000"]
+    assert straxion.find_run_for_hit(hit_seconds * NS, runs) == expected


### PR DESCRIPTION
## Summary
- Add `find_run_for_hit(hit_time, run_ids, run_ends_ns=None)` in `straxion/utils.py` to map a hit's `time` (ns since epoch) to the `run_id` whose window contains it. Run IDs are interpreted as Unix-second timestamp strings (the existing straxion convention).
- Without `run_ends_ns`, the helper treats each run as ending at the next run's start (last run is open-ended). Passing explicit `run_ends_ns` makes gap detection exact — hits between runs return `None`.
- Add `tests/test_find_run_for_hit.py` covering boundaries, gaps, unsorted input, integer run IDs, single-run, empty list, and a parametrized boundary sweep (21 tests).

## Test plan
- [x] `pytest tests/test_find_run_for_hit.py` — 21 passed locally
- [ ] CI green on the PR
