### PR TITLE
Add plot_staggered_traces helper ordered by detector x position

### DIFF
--- a/straxion/colors.py
+++ b/straxion/colors.py
@@ -355,3 +355,119 @@ def plot_channels(
         fig.savefig(save_pdf_at, format="pdf", bbox_inches="tight")
 
     return fig, ax, sc
+
+
+def plot_staggered_traces(
+    records,
+    zooml,
+    zoomr,
+    num_channels=41,
+    sampling_rate=38e3,
+    trace_color="xenon_jet",
+    no_hit_far_channels=None,
+    color_no_hit="xenon_red",
+    single_si_phonon_hits_channels=None,
+    color_single_hit="xenon_blue",
+    time_offset=3e-4,
+    amp_offset=5e-7,
+    ax=None,
+    figsize=(3.5, 2.5),
+    xlim=(0.0, 0.032),
+):
+    """Plot per-channel traces stacked with a staggered time/amplitude offset.
+
+    Channels are ordered left-to-right by their physical x position in the
+    QUALIPHIDE-FIR KID array layout (see :func:`get_channel_position`), so the
+    rank used for the staggered offset reflects detector geometry rather than
+    pulse amplitude.
+
+    Parameters
+    ----------
+    records : dict or structured array
+        Must support indexing ``records["data_dx"][ch][zooml:zoomr]``.
+    zooml, zoomr : int
+        Left/right indices used to slice each trace.
+    num_channels : int, optional
+        Number of channels to iterate over (default 41).
+    sampling_rate : float, optional
+        Sampling rate in Hz used to build the time axis (default 38e3).
+    trace_color : str, optional
+        Color for standard traces (default "xenon_jet").
+    no_hit_far_channels : list or array, optional
+        Channel indices highlighted with ``color_no_hit``.
+    color_no_hit : str, optional
+        Color for no-hit far channels (default "xenon_red").
+    single_si_phonon_hits_channels : int, list, or array, optional
+        Channel index/indices highlighted with ``color_single_hit``.
+    color_single_hit : str, optional
+        Color for single Si phonon hit channels (default "xenon_blue").
+    time_offset : float, optional
+        Time shift added per rank, in seconds (default 3e-4).
+    amp_offset : float, optional
+        Amplitude shift added per rank (default 5e-7).
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If None, a new figure is created.
+    figsize : tuple, optional
+        Figure size if creating new axes (default (3.5, 2.5)).
+    xlim : tuple, optional
+        x-axis limits (default (0.0, 0.032)).
+
+    Returns
+    -------
+    fig, ax
+        Figure and axes objects.
+    """
+    import matplotlib.pyplot as plt
+
+    if no_hit_far_channels is None:
+        no_hit_far_channels = []
+    if single_si_phonon_hits_channels is None:
+        single_si_phonon_hits_channels = []
+    if isinstance(single_si_phonon_hits_channels, (int, np.integer)):
+        single_si_phonon_hits_channels = [single_si_phonon_hits_channels]
+
+    no_hit_far_channels = set(int(c) for c in no_hit_far_channels)
+    single_si_phonon_hits_channels = set(int(c) for c in single_si_phonon_hits_channels)
+
+    traces = []
+    for ch in range(num_channels):
+        rch = records["data_dx"][ch][zooml:zoomr].copy()
+        traces.append(rch)
+
+    channels = np.arange(num_channels)
+    x_positions = get_channel_position(channels)[:, 0]
+    order = np.argsort(x_positions, kind="stable")
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+
+    for rank, ch in enumerate(order):
+        rch = traces[ch]
+        t = np.arange(len(rch)) / sampling_rate
+
+        if ch in single_si_phonon_hits_channels:
+            current_color = color_single_hit
+            current_alpha = 0.6
+            z_order = 3
+        elif ch in no_hit_far_channels:
+            current_color = color_no_hit
+            current_alpha = 0.6
+            z_order = 2
+        else:
+            current_color = trace_color
+            current_alpha = 0.2
+            z_order = 1
+
+        ax.plot(
+            t + time_offset * rank,
+            rch + amp_offset * rank,
+            color=current_color,
+            alpha=current_alpha,
+            lw=0.5,
+            zorder=z_order,
+        )
+
+    ax.set_xlim(xlim)
+    return fig, ax

--- a/tests/test_plot_staggered_traces.py
+++ b/tests/test_plot_staggered_traces.py
@@ -1,0 +1,175 @@
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import straxion  # noqa: E402
+
+straxion.register_xenon_colors()
+
+NUM_CHANNELS = 41
+N_SAMPLES = 2000
+SAMPLING_RATE = 38e3
+
+
+def _make_fake_records(num_channels=NUM_CHANNELS, n_samples=N_SAMPLES, seed=0):
+    """Build a (num_channels, n_samples) fake `data_dx` block.
+
+    Each channel has a Gaussian pulse with peak amplitude ~1e-6, plus low-level
+    noise. The pulse amplitude is channel-dependent so that traces remain
+    distinguishable after plotting.
+    """
+    rng = np.random.default_rng(seed)
+    data_dx = rng.normal(0.0, 1e-8, size=(num_channels, n_samples))
+    t = np.arange(n_samples)
+    for ch in range(num_channels):
+        peak = 1e-6 * (1.0 + 0.01 * ch)
+        data_dx[ch] += peak * np.exp(-((t - n_samples // 2) ** 2) / (50.0**2))
+    return {"data_dx": data_dx}
+
+
+def _expected_x_order(num_channels=NUM_CHANNELS):
+    x_positions = straxion.get_channel_position(np.arange(num_channels))[:, 0]
+    return np.argsort(x_positions, kind="stable")
+
+
+def test_plot_staggered_traces_basic_returns_fig_ax():
+    records = _make_fake_records()
+    fig, ax = straxion.plot_staggered_traces(
+        records, zooml=0, zoomr=N_SAMPLES, sampling_rate=SAMPLING_RATE
+    )
+    assert fig is not None
+    assert ax is not None
+    assert len(ax.lines) == NUM_CHANNELS
+    plt.close(fig)
+
+
+def test_plot_staggered_traces_uses_existing_axes():
+    records = _make_fake_records()
+    fig, ax = plt.subplots()
+    out_fig, out_ax = straxion.plot_staggered_traces(records, zooml=0, zoomr=N_SAMPLES, ax=ax)
+    assert out_ax is ax
+    assert out_fig is fig
+    plt.close(fig)
+
+
+def test_plot_staggered_traces_orders_by_x_position():
+    """Rank in the staggered offset must match left-to-right x order."""
+    records = _make_fake_records()
+    time_offset = 3e-4
+    amp_offset = 5e-7
+
+    fig, ax = straxion.plot_staggered_traces(
+        records,
+        zooml=0,
+        zoomr=N_SAMPLES,
+        sampling_rate=SAMPLING_RATE,
+        time_offset=time_offset,
+        amp_offset=amp_offset,
+    )
+
+    expected_order = _expected_x_order()
+    for rank, line in enumerate(ax.lines):
+        # x offset baked into the line equals time_offset * rank exactly,
+        # since t[0] = 0.
+        assert line.get_xdata()[0] == pytest.approx(time_offset * rank)
+        # Subtracting the rank-dependent amplitude offset recovers the
+        # original channel trace, identifying which channel was plotted at
+        # this rank.
+        ydata = line.get_ydata() - amp_offset * rank
+        ch_expected = expected_order[rank]
+        np.testing.assert_allclose(ydata, records["data_dx"][ch_expected], rtol=0, atol=1e-15)
+
+    # Sanity: the x positions of the channels in plotted order are
+    # monotonically non-decreasing.
+    x_positions = straxion.get_channel_position(np.arange(NUM_CHANNELS))[:, 0]
+    plotted_x = x_positions[expected_order]
+    assert np.all(np.diff(plotted_x) >= 0)
+    plt.close(fig)
+
+
+def test_plot_staggered_traces_not_sorted_by_amplitude():
+    """Regression: ordering must reflect geometry, not amplitude.
+
+    Channels here have monotonically increasing amplitude with channel index,
+    so amplitude-sorting would produce a different rank order than
+    x-position sorting (the array layout is not channel-monotonic in x).
+    """
+    records = _make_fake_records()
+    fig, ax = straxion.plot_staggered_traces(
+        records, zooml=0, zoomr=N_SAMPLES, sampling_rate=SAMPLING_RATE
+    )
+
+    expected_order = _expected_x_order()
+    # Amplitude-descending order, then the butterfly fold the old function used.
+    amps = np.array([np.nanmax(records["data_dx"][ch]) for ch in range(NUM_CHANNELS)])
+    amp_order = np.argsort(amps)[::-1]
+    butterfly = np.concatenate((amp_order[::2][::-1], amp_order[1::2]))
+
+    assert not np.array_equal(expected_order, butterfly)
+    plt.close(fig)
+
+
+def test_plot_staggered_traces_highlight_colors():
+    records = _make_fake_records()
+    hit_ch = 16
+    far_ch = 0
+    fig, ax = straxion.plot_staggered_traces(
+        records,
+        zooml=0,
+        zoomr=N_SAMPLES,
+        single_si_phonon_hits_channels=hit_ch,
+        no_hit_far_channels=[far_ch],
+        trace_color="xenon_jet",
+        color_single_hit="xenon_blue",
+        color_no_hit="xenon_red",
+    )
+
+    expected_order = _expected_x_order()
+    hit_rank = int(np.where(expected_order == hit_ch)[0][0])
+    far_rank = int(np.where(expected_order == far_ch)[0][0])
+
+    # Verify color, alpha, and zorder for highlighted vs. background traces.
+    hit_line = ax.lines[hit_rank]
+    far_line = ax.lines[far_rank]
+
+    assert matplotlib.colors.to_hex(hit_line.get_color()) == matplotlib.colors.to_hex("xenon_blue")
+    assert hit_line.get_alpha() == pytest.approx(0.6)
+    assert hit_line.get_zorder() == 3
+
+    assert matplotlib.colors.to_hex(far_line.get_color()) == matplotlib.colors.to_hex("xenon_red")
+    assert far_line.get_alpha() == pytest.approx(0.6)
+    assert far_line.get_zorder() == 2
+
+    # A background channel (not in either highlight set) should be the
+    # default trace color with low alpha.
+    bg_ch = next(c for c in range(NUM_CHANNELS) if c not in (hit_ch, far_ch))
+    bg_rank = int(np.where(expected_order == bg_ch)[0][0])
+    bg_line = ax.lines[bg_rank]
+    assert matplotlib.colors.to_hex(bg_line.get_color()) == matplotlib.colors.to_hex("xenon_jet")
+    assert bg_line.get_alpha() == pytest.approx(0.2)
+    assert bg_line.get_zorder() == 1
+    plt.close(fig)
+
+
+def test_plot_staggered_traces_accepts_int_hit_channel():
+    records = _make_fake_records()
+    # Should not raise when a bare int is passed instead of a list.
+    fig, _ = straxion.plot_staggered_traces(
+        records, zooml=0, zoomr=N_SAMPLES, single_si_phonon_hits_channels=5
+    )
+    plt.close(fig)
+
+
+def test_plot_staggered_traces_respects_zoom_slice():
+    records = _make_fake_records()
+    zooml, zoomr = 200, 700
+    fig, ax = straxion.plot_staggered_traces(
+        records, zooml=zooml, zoomr=zoomr, sampling_rate=SAMPLING_RATE
+    )
+    # Each line should carry zoomr - zooml samples.
+    for line in ax.lines:
+        assert len(line.get_xdata()) == zoomr - zooml
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- Add `plot_staggered_traces` to `straxion/colors.py`. It plots all 41 channel traces with a staggered time/amplitude offset, ranked **left-to-right by physical x position** (via `get_channel_position`) instead of the old amplitude butterfly fold.
- Highlight sets for no-hit-far channels and single Si phonon hit channels are preserved; `time_offset`, `amp_offset`, `ax`, `figsize`, and `xlim` are now parameters so the helper composes with existing figures.
- Add `tests/test_plot_staggered_traces.py` with fake `data_dx` waveforms (peak ~1e-6, Gaussian pulse + noise) covering ordering, highlight color/alpha/zorder, single-int hit-channel input, existing-axes reuse, zoom slicing, and a regression guard that the new order is not the old amplitude butterfly.

## Example usage

```python
import matplotlib.pyplot as plt
import straxion

straxion.register_xenon_colors()

# `records` is the strax records array; records["data_dx"][ch] gives the
# per-sample dx trace for frequency channel `ch`.
records = st.get_array(run_id, "records")

# Zoom into a 32 ms window around a hit, highlight the hit channel in blue
# and a couple of far no-hit channels in red.
fig, ax = straxion.plot_staggered_traces(
    records,
    zooml=12000,
    zoomr=13200,
    sampling_rate=38e3,
    single_si_phonon_hits_channels=16,        # int or list of channels
    no_hit_far_channels=[0, 40],
)
ax.set_xlabel("time + stagger [s]")
ax.set_ylabel(r"$dx$ + stagger")
plt.show()
```

Channels at the left edge of the array appear at the bottom of the stack and those at the right edge at the top, so the staggered view directly mirrors the detector geometry. Tune `time_offset` / `amp_offset` to compress or spread the stack, or pass an existing `ax=` to drop it into a multi-panel figure.

## Test plan
- [x] `pytest tests/test_plot_staggered_traces.py` — 7 passed
- [x] `pytest tests/test_colors.py tests/test_channel_position.py` — 24 passed, no regressions

Generated with [Claude Code](https://claude.com/claude-code)
